### PR TITLE
Remove BulletPhysics pragma "true" that causes compile error without SIMD

### DIFF
--- a/libsrc/bullet3-3.24/LinearMath/btMatrix3x3.h
+++ b/libsrc/bullet3-3.24/LinearMath/btMatrix3x3.h
@@ -323,7 +323,7 @@ public:
 	/**@brief Set the matrix to the identity */
 	void setIdentity()
 	{
-#if (defined(BT_USE_SSE_IN_API) && defined(BT_USE_SSE)) || defined(BT_USE_NEON) || true
+#if (defined(BT_USE_SSE_IN_API) && defined(BT_USE_SSE)) || defined(BT_USE_NEON)
 		m_el[0] = v1000;
 		m_el[1] = v0100;
 		m_el[2] = v0010;


### PR DESCRIPTION
RocketSim can now be compiled without SIMD

This was the easiest way for me to get this to compile with Clang on Windows plz accept fix