### PR TITLE
Fix Angle operator<< typo (pass stream by ref)

### DIFF
--- a/src/BulletLink.h
+++ b/src/BulletLink.h
@@ -35,7 +35,7 @@ static inline std::ostream& operator <<(std::ostream& stream, const btVector3& v
 }
 
 // For printing Angle
-static inline std::ostream& operator <<(std::ostream stream, const Angle& ang) {
+static inline std::ostream& operator <<(std::ostream& stream, const Angle& ang) {
 	stream << "(YPR)[ " << ang.yaw << ", " << ang.pitch << ", " << ang.roll << " ]";
 	return stream;
 }


### PR DESCRIPTION
Prevents returning a reference to stack memory.