### PR TITLE
Fix accidental semicolon after #include directive

### DIFF
--- a/src/Sim/Ball/Ball.cpp
+++ b/src/Sim/Ball/Ball.cpp
@@ -1,6 +1,6 @@
 #include "Ball.h"
 
-#include "../../RLConst.h";
+#include "../../RLConst.h"
 
 BallState Ball::GetState() {
 	BallState stateOut;


### PR DESCRIPTION
Fixes a fairly benign warning, but good to get rid of it to prevent warning blindness.