### PR TITLE
Avoid redefinition of MAX_ITERATIONS macro

### DIFF
--- a/libsrc/bullet3-3.24/BulletCollision/NarrowPhaseCollision/btContinuousConvexCollision.cpp
+++ b/libsrc/bullet3-3.24/BulletCollision/NarrowPhaseCollision/btContinuousConvexCollision.cpp
@@ -43,7 +43,7 @@ btContinuousConvexCollision::btContinuousConvexCollision(const btConvexShape* co
 
 /// This maximum should not be necessary. It allows for untested/degenerate cases in production code.
 /// You don't want your game ever to lock-up.
-#define MAX_ITERATIONS 64
+#define BT_CONT_CONVEX_MAX_ITERATIONS 64
 
 void btContinuousConvexCollision::computeClosestPoints(const btTransform& transA, const btTransform& transB, btPointCollector& pointCollector)
 {
@@ -205,7 +205,7 @@ bool btContinuousConvexCollision::calcTimeOfImpact(
 			}
 
 			numIter++;
-			if (numIter > MAX_ITERATIONS)
+			if (numIter > BT_CONT_CONVEX_MAX_ITERATIONS)
 			{
 				result.reportFailure(-2, numIter);
 				return false;


### PR DESCRIPTION
This triggers a warning under Clang on macOS