### PR TITLE
keep cars in position when demoed instead of 0, 0, -50000 from simulator

### DIFF
--- a/src/Sim/Car/Car.cpp
+++ b/src/Sim/Car/Car.cpp
@@ -6,14 +6,15 @@
 
 // Update our internal state from bullet and return it
 CarState Car::GetState() {
-	_internalState.pos = _rigidBody.m_worldTransform.m_origin * BT_TO_UU;
+	if (!_internalState.isDemoed) {
+		_internalState.pos = _rigidBody.m_worldTransform.m_origin * BT_TO_UU;
 
-	// NOTE: rotMat already updated at the start of Car::_PostTickUpdate()
+		// NOTE: rotMat already updated at the start of Car::_PostTickUpdate()
 
-	_internalState.vel = _rigidBody.m_linearVelocity * BT_TO_UU;
+		_internalState.vel = _rigidBody.m_linearVelocity * BT_TO_UU;
 
-	_internalState.angVel = _rigidBody.m_angularVelocity;
-
+		_internalState.angVel = _rigidBody.m_angularVelocity;
+    }
 	return _internalState;
 }
 


### PR DESCRIPTION
changed the car position to stay where it is when demoed. This has been implemented for months in mtheall python bindings, but this is necessary for the rust rocketsim-rs to pick it up. It's running fine and built fine on my machine.