### PR TITLE
Reduce allocations during runtime

### DIFF
--- a/rocketsim/examples/rocket_sim_vis_compare.rs
+++ b/rocketsim/examples/rocket_sim_vis_compare.rs
@@ -16,7 +16,7 @@ use crate::state_convert::{
 
 /////////////////
 
-const ROCKET_SIM_VIS_ADDRESS: &'static str = "127.0.0.1:9273";
+const ROCKET_SIM_VIS_ADDRESS: &str = "127.0.0.1:9273";
 
 #[derive(Serialize)]
 struct PhysStateView {

--- a/rocketsim/examples/vis.rs
+++ b/rocketsim/examples/vis.rs
@@ -1,5 +1,4 @@
 use device_query::{DeviceQuery, DeviceState, Keycode};
-use egui::Key;
 use glam::Vec3A;
 use rocketsim::{
     Arena, ArenaConfig, CarBodyConfig, CarControls, GameMode, Team, init_from_default,
@@ -65,10 +64,10 @@ fn main() {
     loop {
         let held_keys = device_state.get_keys();
 
-        let mut pressed_keys: Vec<Keycode> = held_keys
+        let pressed_keys: Vec<Keycode> = held_keys
             .iter()
-            .cloned()
-            .filter(|key| !prev_keys.contains(key))
+            .filter(|&key| !prev_keys.contains(key))
+            .copied()
             .collect();
 
         let controls = determine_controls(&device_state);

--- a/rocketsim/rocketsim_derive/src/lib.rs
+++ b/rocketsim/rocketsim_derive/src/lib.rs
@@ -11,7 +11,7 @@ pub fn fast_hash_struct(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let name = &input.ident;
 
     let expanded = quote! {
-        #[repr(packed)]
+        #[repr(Rust, packed)]
         #[derive(zerocopy::Immutable, zerocopy::IntoBytes)]
         #input
         derive_hash_fast::derive_hash_fast_zerocopy!(#name);

--- a/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
+++ b/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
@@ -146,7 +146,7 @@ impl CollisionDispatcher {
             return;
         }
 
-        if let Some(manifold) = Self::process_collision(&rb0, &rb1, contact_added_callback) {
+        if let Some(manifold) = Self::process_collision(rb0, rb1, contact_added_callback) {
             self.manifolds.push(manifold);
         }
     }

--- a/rocketsim/src/bullet/collision/dispatch/ray_packet_callbacks.rs
+++ b/rocketsim/src/bullet/collision/dispatch/ray_packet_callbacks.rs
@@ -138,7 +138,7 @@ impl<T: RayResultCallback> BroadphaseAabbCallback for QuadRayCallback<'_, T> {
             CollisionWorld::quad_ray_test(
                 self.ray_from_world,
                 self.ray_to_world,
-                &rb,
+                rb,
                 obj_idx,
                 self.result_callback,
             );

--- a/rocketsim/src/bullet/collision/shapes/sphere_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/sphere_shape.rs
@@ -16,7 +16,6 @@ pub struct SphereShape {
 
 impl SphereShape {
     #[inline]
-
     pub const fn new(radius: f32) -> Self {
         Self {
             convex_internal_shape: ConvexInternalShape {
@@ -27,13 +26,11 @@ impl SphereShape {
     }
 
     #[inline]
-
     pub fn get_radius(&self) -> f32 {
         self.convex_internal_shape.implicit_dim.x
     }
 
     #[inline]
-
     pub fn get_margin(&self) -> f32 {
         self.get_radius()
     }

--- a/rocketsim/src/bullet/dynamics/vehicle/vehicle_rl.rs
+++ b/rocketsim/src/bullet/dynamics/vehicle/vehicle_rl.rs
@@ -368,7 +368,7 @@ impl VehicleRL {
 
         let friction_scale = chassis.get_mass() / 3.0;
         for wheel in &mut self.wheels {
-            wheel.update_wheel_trans(&chassis);
+            wheel.update_wheel_trans(chassis);
         }
 
         let mut sources = [Vec3A::ZERO; 4];
@@ -381,7 +381,7 @@ impl VehicleRL {
 
         let ray_results = self
             .raycaster
-            .cast_rays(collision_world, &sources, &targets, &chassis);
+            .cast_rays(collision_world, &sources, &targets, chassis);
 
         for (i, wheel) in self.wheels.iter_mut().enumerate() {
             if let Some(ray_result) = ray_results[i] {

--- a/rocketsim/src/shared/bvh.rs
+++ b/rocketsim/src/shared/bvh.rs
@@ -8,24 +8,6 @@ pub trait ProcessNode {
     fn process_node(&mut self, leaf_idx: usize);
 }
 
-/// Just adds all the leaf indices to a Vec<usize>
-#[derive(Debug, Clone)]
-pub struct SimpleNodeProcessor {
-    pub leaf_indices: Vec<usize>,
-}
-impl SimpleNodeProcessor {
-    pub fn new() -> Self {
-        Self {
-            leaf_indices: Vec::new(),
-        }
-    }
-}
-impl ProcessNode for SimpleNodeProcessor {
-    fn process_node(&mut self, leaf_idx: usize) {
-        self.leaf_indices.push(leaf_idx);
-    }
-}
-
 pub trait ProcessRayPacketNode {
     fn process_packet_node(&mut self, leaf_idx: usize, active_mask: u8, lambda_max: &mut Vec4);
 }

--- a/rocketsim/src/sim/arena/arena_contact_tracker.rs
+++ b/rocketsim/src/sim/arena/arena_contact_tracker.rs
@@ -29,8 +29,16 @@ impl ArenaContactTracker {
         }
     }
 
-    pub fn drain_records(&mut self) -> Vec<ContactRecord> {
-        self.collision_records.drain(..).collect()
+    pub fn num_records(&self) -> usize {
+        self.collision_records.len()
+    }
+
+    pub fn get_record(&self, idx: usize) -> &ContactRecord {
+        &self.collision_records[idx]
+    }
+
+    pub fn clear_records(&mut self) {
+        self.collision_records.clear();
     }
 }
 

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -356,34 +356,37 @@ impl Arena {
             for cur_team in Team::ALL {
                 let is_blue = cur_team == Team::Blue;
 
-                let mut team_car_indices = Vec::with_capacity(self.cars.len());
+                let mut team_car_count = 0;
+                let mut car_idx = None;
+
                 for car in &self.cars {
                     if car.team == cur_team {
-                        team_car_indices.push(car.idx);
+                        team_car_count += 1;
+
+                        if team_car_count == i + 1 {
+                            car_idx = Some(car.idx);
+                            break;
+                        }
                     }
                 }
 
-                if team_car_indices.len() <= i {
-                    continue;
+                if let Some(car_idx) = car_idx {
+                    spawn_state.phys.rot_mat = Mat3A::from_euler(
+                        EulerRot::ZYX,
+                        if is_blue {
+                            spawn_pos.yaw_ang
+                        } else {
+                            spawn_state.phys.pos *= Vec3A::new(-1.0, -1.0, 1.0);
+                            spawn_pos.yaw_ang + if is_blue { 0.0 } else { PI }
+                        },
+                        0.0,
+                        0.0,
+                    );
+
+                    let car = &mut self.cars[car_idx];
+                    let rb = &mut self.bullet_world.bodies_mut()[car.rigid_body_idx];
+                    car.set_state(rb, &spawn_state);
                 }
-
-                let car_idx = team_car_indices[i];
-
-                spawn_state.phys.rot_mat = Mat3A::from_euler(
-                    EulerRot::ZYX,
-                    if is_blue {
-                        spawn_pos.yaw_ang
-                    } else {
-                        spawn_state.phys.pos *= Vec3A::new(-1.0, -1.0, 1.0);
-                        spawn_pos.yaw_ang + if is_blue { 0.0 } else { PI }
-                    },
-                    0.0,
-                    0.0,
-                );
-
-                let car = &mut self.cars[car_idx];
-                let rb = &mut self.bullet_world.bodies_mut()[car.rigid_body_idx];
-                car.set_state(rb, &spawn_state);
             }
         }
 

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -462,13 +462,15 @@ impl Arena {
 
         self.bullet_world
             .step_simulation(TICK_TIME, &mut self.contact_tracker);
-        for contact in self.contact_tracker.drain_records() {
-            let (body_a, body_b) = self
+
+        let contact_count = self.contact_tracker.num_records();
+        for idx in 0..contact_count {
+            let contact = *self.contact_tracker.get_record(idx);
+            let [body_a, body_b] = self
                 .bullet_world
                 .bodies_mut()
                 .get_disjoint_mut([contact.rb_idx_a, contact.rb_idx_b])
-                .unwrap()
-                .into();
+                .unwrap();
 
             let user_pointer_a = body_a.user_pointer;
             let user_pointer_b = body_b.user_pointer;
@@ -495,6 +497,8 @@ impl Arena {
                 self.on_ball_world_collision(&contact.manifold_point);
             }
         }
+
+        self.contact_tracker.clear_records();
 
         for car in &mut self.cars {
             let rb = &mut self.bullet_world.bodies_mut()[car.rigid_body_idx];

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -5,7 +5,6 @@ use crate::consts::{TICK_RATE, TICK_TIME};
 use crate::sim::ArenaEvent::CarHitBall;
 use crate::sim::arena::ArenaEventList;
 use crate::sim::{ArenaEvent, Ball, BoostPad, CarHitBallEvent, CarHitCarEvent, CarHitWorldEvent};
-use crate::vis::VisInst;
 use crate::{
     ARENA_COLLISION_MESH_FILES, ARENA_COLLISION_SHAPES, ArenaConfig, ArenaMemWeightMode,
     ArenaState, BallHitWorldEvent, BoostPadConfig, BoostPadGrid, BoostPadState, Car, CarBodyConfig,
@@ -31,6 +30,9 @@ use arrayvec::ArrayVec;
 use fastrand::Rng;
 use glam::{Affine3A, EulerRot, Mat3A, Vec3A};
 use std::{f32::consts::PI, iter::repeat_n, mem};
+
+#[cfg(feature = "vis")]
+use crate::vis::VisInst;
 
 pub struct Arena {
     pub(crate) bullet_world: DiscreteDynamicsWorld,
@@ -535,19 +537,16 @@ impl Arena {
     }
 
     #[inline]
-
     pub const fn tick_count(&self) -> u64 {
         self.tick_count
     }
 
     #[inline]
-
     pub const fn game_mode(&self) -> GameMode {
         self.game_mode
     }
 
     #[inline]
-
     pub const fn mutator_config(&self) -> &MutatorConfig {
         &self.mutator_config
     }
@@ -564,7 +563,6 @@ impl Arena {
     }
 
     #[inline]
-
     pub const fn cars(&self) -> &Vec<Car> {
         &self.cars
     }
@@ -655,14 +653,12 @@ impl Arena {
 
     pub fn get_all_boost_pad_states(&self) -> Vec<BoostPadState> {
         (0..self.num_boost_pads())
-            .into_iter()
             .map(|i| self.get_boost_pad_state(i))
             .collect()
     }
 
     pub fn get_all_boost_pad_configs(&self) -> Vec<BoostPadConfig> {
         (0..self.num_boost_pads())
-            .into_iter()
             .map(|i| *self.get_boost_pad_config(i))
             .collect()
     }
@@ -688,10 +684,12 @@ impl Arena {
         self.events.events()
     }
 
+    #[cfg(feature = "vis")]
     pub fn get_vis_enabled(&self) -> bool {
         self.vis_inst.is_some()
     }
 
+    #[cfg(feature = "vis")]
     pub fn set_vis_enabled(&mut self, vis_enabled: bool) {
         if vis_enabled && self.vis_inst.is_none() {
             // Create visualizer

--- a/rocketsim/src/sim/boost_pad/boost_pad_grid.rs
+++ b/rocketsim/src/sim/boost_pad/boost_pad_grid.rs
@@ -1,7 +1,45 @@
 use crate::consts::TICK_TIME;
-use crate::shared::bvh::SimpleNodeProcessor;
 use crate::shared::{Aabb, bvh};
 use crate::{BoostPad, BoostPadConfig, CarState, MutatorConfig, consts::boost_pads};
+
+pub struct BoostPadProcessor<'a> {
+    all_pads: &'a mut [BoostPad],
+    car_state: &'a mut CarState,
+    mutator_config: &'a MutatorConfig,
+    tick_count: u64,
+    pad_idx: Option<usize>,
+}
+
+impl<'a> bvh::ProcessNode for BoostPadProcessor<'a> {
+    fn process_node(&mut self, pad_idx: usize) {
+        if self.pad_idx.is_some() {
+            return; // Already found a pad to give boost from, no need to check more
+        }
+
+        let pad = &mut self.all_pads[pad_idx];
+
+        if let Some(last_give_tick_count) = pad.gave_boost_tick_count
+            && ((self.tick_count - last_give_tick_count) as f32 * TICK_TIME) < pad.max_cooldown
+        {
+            return;
+        }
+
+        // Check if car origin is inside the cylinder hitbox
+        let pad_pos = pad.config().pos;
+        let dist_sq_2d = pad_pos
+            .truncate()
+            .distance_squared(self.car_state.pos.truncate());
+        let overlapping = dist_sq_2d < pad.cyl_radius.powi(2)
+            && (self.car_state.pos.z - pad_pos.z).abs() <= boost_pads::CYL_HEIGHT;
+        if overlapping {
+            // Give boost
+            self.car_state.boost = (self.car_state.boost + pad.boost_amount)
+                .min(self.mutator_config.car_max_boost_amount);
+            pad.gave_boost_tick_count = Some(self.tick_count);
+            self.pad_idx = Some(pad_idx);
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct BoostPadGrid {
@@ -86,35 +124,17 @@ impl BoostPadGrid {
         }
 
         let car_center_aabb = Aabb::new(car_state.pos, car_state.pos);
-        let mut node_processor = SimpleNodeProcessor::new();
+
+        let mut pad_processor = BoostPadProcessor {
+            all_pads: &mut self.all_pads,
+            car_state,
+            mutator_config,
+            tick_count,
+            pad_idx: None,
+        };
         self.bvh_tree
-            .report_aabb_overlapping_node(&mut node_processor, &car_center_aabb);
+            .report_aabb_overlapping_node(&mut pad_processor, &car_center_aabb);
 
-        for pad_idx in node_processor.leaf_indices {
-            let pad = &mut self.all_pads[pad_idx];
-
-            if let Some(last_give_tick_count) = pad.gave_boost_tick_count
-                && ((tick_count - last_give_tick_count) as f32 * TICK_TIME) < pad.max_cooldown
-            {
-                continue;
-            }
-
-            // Check if car origin is inside the cylinder hitbox
-            let pad_pos = pad.config().pos;
-            let dist_sq_2d = pad_pos
-                .truncate()
-                .distance_squared(car_state.pos.truncate());
-            let overlapping = dist_sq_2d < pad.cyl_radius.powi(2)
-                && (car_state.pos.z - pad_pos.z).abs() <= boost_pads::CYL_HEIGHT;
-            if overlapping {
-                // Give boost
-                car_state.boost =
-                    (car_state.boost + pad.boost_amount).min(mutator_config.car_max_boost_amount);
-                pad.gave_boost_tick_count = Some(tick_count);
-                return Some(pad_idx);
-            }
-        }
-
-        None
+        pad_processor.pad_idx
     }
 }

--- a/rocketsim/src/sim/boost_pad/boost_pad_grid.rs
+++ b/rocketsim/src/sim/boost_pad/boost_pad_grid.rs
@@ -11,13 +11,12 @@ pub(crate) struct BoostPadGrid {
 }
 
 impl BoostPadGrid {
-    pub fn new(pad_configs: &Vec<BoostPadConfig>, mutator_config: &MutatorConfig) -> Self {
+    pub fn new(pad_configs: &[BoostPadConfig], mutator_config: &MutatorConfig) -> Self {
         assert!(!pad_configs.is_empty());
 
         let mut all_pads: Vec<BoostPad> = pad_configs
-            .clone()
-            .into_iter()
-            .map(|pad_config| BoostPad::new(pad_config, mutator_config))
+            .iter()
+            .map(|&pad_config| BoostPad::new(pad_config, mutator_config))
             .collect();
 
         // Sort them to match RLBot/RLGym ordering

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -113,7 +113,7 @@ impl Car {
             }
 
             bullet_vehicle.add_wheel(
-                &rb,
+                rb,
                 wheel_ray_start_offset * UU_TO_BT,
                 wheel_direction_cs,
                 wheel_axle_cs,

--- a/rocketsim/src/sim/consts.rs
+++ b/rocketsim/src/sim/consts.rs
@@ -16,7 +16,6 @@ pub struct CarSpawnPos {
 
 impl CarSpawnPos {
     #[inline]
-
     pub const fn new(x: f32, y: f32, yaw_ang: f32) -> Self {
         Self { x, y, yaw_ang }
     }

--- a/rocketsim/src/sim/linear_piece_curve.rs
+++ b/rocketsim/src/sim/linear_piece_curve.rs
@@ -15,7 +15,6 @@ pub struct LinearPieceCurve<const N: usize> {
 
 impl<const N: usize> LinearPieceCurve<N> {
     /// A mapping of `(x, y)` pairs that make up the continuous linear piecewise function
-
     pub const fn new(value_mappings: [(f32, f32); N]) -> Self {
         let mut curve = [LinearPiece {
             base_x: 0.0,
@@ -52,7 +51,6 @@ impl<const N: usize> LinearPieceCurve<N> {
     /// # Arguments
     ///
     /// * `input` - The input to the curve
-
     pub fn get_output(&self, input: f32) -> f32 {
         debug_assert!(N != 0);
 

--- a/rocketsim/src/vis/backend/model.rs
+++ b/rocketsim/src/vis/backend/model.rs
@@ -24,8 +24,8 @@ impl Model {
             let m_verts = mesh.get_vertices();
             for tri in mesh.get_indices().chunks(3) {
                 let tri_verts = [m_verts[tri[0]], m_verts[tri[1]], m_verts[tri[2]]];
-                for i in 0..3 {
-                    verts.push(tri_verts[i].to_vec3() * BT_TO_UU);
+                for vert in tri_verts {
+                    verts.push(vert.to_vec3() * BT_TO_UU);
                     vert_uvs.push(Vec2::splat(0.5)); // Middle UVs
                 }
             }

--- a/rocketsim/src/vis/backend/vis_renderer.rs
+++ b/rocketsim/src/vis/backend/vis_renderer.rs
@@ -162,7 +162,7 @@ impl VisRenderer {
             };
         }
 
-        assert!(line_shaders.len() > 0, "Missing line shaders");
+        assert!(!line_shaders.is_empty(), "Missing line shaders");
         assert!(line_shaders.len() < 2, "Cannot have multiple line shaders");
 
         let color_blend = Some(BlendState::new(
@@ -502,14 +502,15 @@ impl VisRenderer {
         shared_render_state: SharedVisRenderState,
         shader_srcs: Vec<(&str, ShaderSrc)>,
     ) -> (JoinHandle<()>, SharedWindowEvents) {
-        let mut conf = conf::Conf::default();
-
-        conf.window_title = window_title.to_string();
-        conf.window_width = 1280;
-        conf.window_height = 720;
+        let mut conf = conf::Conf {
+            window_title: window_title.to_string(),
+            window_width: 1280,
+            window_height: 720,
+            sample_count: 8, // Heavy MSAA
+            ..Default::default()
+        };
 
         conf.platform.apple_gfx_api = conf::AppleGfxApi::OpenGl; // Apple devices should still use OpenGL
-        conf.sample_count = 8; // Heavy MSAA
 
         let shader_srcs_strings: Vec<(String, ShaderSrc)> = shader_srcs
             .iter()

--- a/rocketsim/src/vis/ribbon_emitter.rs
+++ b/rocketsim/src/vis/ribbon_emitter.rs
@@ -116,7 +116,7 @@ impl RibbonEmitter {
     }
 
     pub fn reset(&mut self) {
-        *self = RibbonEmitter::new(self.config.clone());
+        *self = RibbonEmitter::new(self.config);
     }
 
     pub fn render(&mut self, render_state: &mut VisRenderState, emit_pos: Vec3A) {

--- a/rocketsim/tests/comparison_test/control_seq.rs
+++ b/rocketsim/tests/comparison_test/control_seq.rs
@@ -24,7 +24,7 @@ impl ControlSeq {
         }
 
         if let Some(car_controls) = self.car_controls.get(tick as usize) {
-            car_controls.clone()
+            *car_controls
         } else {
             *self.car_controls.last().unwrap()
         }
@@ -33,7 +33,7 @@ impl ControlSeq {
     pub fn add(mut self, controls: CarControls, duration: u64) -> Self {
         assert!(duration > 0);
         for _ in 0..duration {
-            self.car_controls.push(controls.clone());
+            self.car_controls.push(controls);
         }
         self
     }


### PR DESCRIPTION
Fixed compilation without the `vis` feature.
Fixed a few lints while at it.

Before vs after allocation-related fixes:
<img width="1335" height="903" alt="image" src="https://github.com/user-attachments/assets/c7fa7c57-7158-46e1-9e42-172ad615c031" />
<img width="1338" height="929" alt="image" src="https://github.com/user-attachments/assets/7103c5c0-97be-4d27-a420-ca0e2e82f111" />
