### PR TITLE
Allow configing mutators + 2 fixes

### DIFF
--- a/rocketsim/examples/stress.rs
+++ b/rocketsim/examples/stress.rs
@@ -158,13 +158,10 @@ fn main() {
     let cli = Args::parse();
 
     init_from_default(true).unwrap();
-    let mut arena = Arena::new_with_config(
-        cli.game_mode.into(),
-        ArenaConfig {
-            rng_seed: Some(0),
-            ..Default::default()
-        },
-    );
+    let mut arena = Arena::new_with_config(ArenaConfig {
+        rng_seed: Some(0),
+        ..ArenaConfig::new(cli.game_mode.into())
+    });
 
     fastrand::seed(0);
 

--- a/rocketsim/examples/vis.rs
+++ b/rocketsim/examples/vis.rs
@@ -47,13 +47,10 @@ fn determine_controls(device: &DeviceState) -> CarControls {
 
 fn main() {
     init_from_default(true).unwrap();
-    let mut arena = Arena::new_with_config(
-        GameMode::Soccar,
-        ArenaConfig {
-            rng_seed: Some(0),
-            ..Default::default()
-        },
-    );
+    let mut arena = Arena::new_with_config(ArenaConfig {
+        rng_seed: Some(0),
+        ..ArenaConfig::new(GameMode::Soccar)
+    });
 
     let car_idx = arena.add_car(Team::Blue, CarBodyConfig::BREAKOUT);
 

--- a/rocketsim/src/sim/arena/arena_config.rs
+++ b/rocketsim/src/sim/arena/arena_config.rs
@@ -1,4 +1,4 @@
-use crate::BoostPadConfig;
+use crate::{BoostPadConfig, GameMode, MutatorConfig};
 use glam::Vec3A;
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
@@ -10,6 +10,8 @@ pub enum ArenaMemWeightMode {
 
 #[derive(Clone, Debug)]
 pub struct ArenaConfig {
+    pub game_mode: GameMode,
+    pub mutators: MutatorConfig,
     pub mem_weight_mode: ArenaMemWeightMode,
     pub min_pos: Vec3A,
     pub max_pos: Vec3A,
@@ -31,6 +33,8 @@ impl Default for ArenaConfig {
 
 impl ArenaConfig {
     pub const DEFAULT: Self = Self {
+        game_mode: GameMode::Soccar,
+        mutators: MutatorConfig::new(GameMode::Soccar),
         mem_weight_mode: ArenaMemWeightMode::Heavy,
         min_pos: Vec3A::new(-5600., -6000., 0.),
         max_pos: Vec3A::new(5600., 6000., 2200.),
@@ -39,4 +43,12 @@ impl ArenaConfig {
         custom_boost_pads: None,
         rng_seed: None,
     };
+
+    pub fn new(game_mode: GameMode) -> Self {
+        Self {
+            game_mode,
+            mutators: MutatorConfig::new(game_mode),
+            ..Self::DEFAULT
+        }
+    }
 }

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -6,9 +6,9 @@ use crate::sim::ArenaEvent::CarHitBall;
 use crate::sim::arena::ArenaEventList;
 use crate::sim::{ArenaEvent, Ball, BoostPad, CarHitBallEvent, CarHitCarEvent, CarHitWorldEvent};
 use crate::{
-    ARENA_COLLISION_MESH_FILES, ARENA_COLLISION_SHAPES, ArenaConfig, ArenaMemWeightMode,
-    ArenaState, BallHitWorldEvent, BoostPadConfig, BoostPadGrid, BoostPadState, Car, CarBodyConfig,
-    CarControls, CarInfo, CarPickupBoostEvent, CarState, GameMode, MutatorConfig, PhysState, Team,
+    ARENA_COLLISION_SHAPES, ArenaConfig, ArenaMemWeightMode, ArenaState, BallHitWorldEvent,
+    BoostPadConfig, BoostPadGrid, BoostPadState, Car, CarBodyConfig, CarControls, CarInfo,
+    CarPickupBoostEvent, CarState, GameMode, MutatorConfig, PhysState, Team,
     bullet::{
         collision::{
             broadphase::{GridBroadphase, HashedOverlappingPairCache},
@@ -42,8 +42,6 @@ pub struct Arena {
     pub(crate) ball: Ball,
     pub(crate) cars: Vec<Car>,
     pub(crate) tick_count: u64,
-    pub(crate) game_mode: GameMode,
-    pub(crate) mutator_config: MutatorConfig,
     pub(crate) boost_pad_grid: Option<BoostPadGrid>,
     pub(crate) contact_tracker: ArenaContactTracker,
     pub(crate) events: ArenaEventList,
@@ -54,12 +52,10 @@ pub struct Arena {
 
 impl Arena {
     pub fn new(game_mode: GameMode) -> Self {
-        Self::new_with_config(game_mode, ArenaConfig::DEFAULT)
+        Self::new_with_config(ArenaConfig::new(game_mode))
     }
 
-    pub fn new_with_config(game_mode: GameMode, config: ArenaConfig) -> Self {
-        let mutator_config = MutatorConfig::new(game_mode);
-
+    pub fn new_with_config(config: ArenaConfig) -> Self {
         let collision_dispatcher = CollisionDispatcher::default();
         let constraint_solver = SeqImpulseConstraintSolver::default();
         let overlapping_pair_cache = HashedOverlappingPairCache::default();
@@ -79,28 +75,28 @@ impl Arena {
 
         let mut bullet_world =
             DiscreteDynamicsWorld::new(collision_dispatcher, broadphase, constraint_solver);
-        bullet_world.set_gravity(mutator_config.gravity * UU_TO_BT);
+        bullet_world.set_gravity(config.mutators.gravity * UU_TO_BT);
 
-        if game_mode != GameMode::TheVoid {
-            Self::setup_arena_collision_shapes(&mut bullet_world, game_mode);
+        if config.game_mode != GameMode::TheVoid {
+            Self::setup_arena_collision_shapes(&mut bullet_world, config.game_mode);
         }
 
         let ball = Ball::new(
-            game_mode,
+            config.game_mode,
             &mut bullet_world,
-            &mutator_config,
+            &config.mutators,
             config.no_ball_rot,
         );
 
         let mut boost_pad_grid = None;
-        if game_mode != GameMode::TheVoid && game_mode != GameMode::Dropshot {
+        if config.game_mode != GameMode::TheVoid && config.game_mode != GameMode::Dropshot {
             let mut boost_pad_configs = Vec::new();
 
             if let Some(custom_boost_pads) = config.custom_boost_pads.as_ref() {
                 boost_pad_configs.extend_from_slice(custom_boost_pads);
             } else {
-                let small_pad_locs = consts::boost_pads::get_locations(game_mode, false);
-                let big_pad_locs = consts::boost_pads::get_locations(game_mode, true);
+                let small_pad_locs = consts::boost_pads::get_locations(config.game_mode, false);
+                let big_pad_locs = consts::boost_pads::get_locations(config.game_mode, true);
                 boost_pad_configs.reserve(small_pad_locs.len() + big_pad_locs.len());
 
                 for small_pos in small_pad_locs {
@@ -118,7 +114,7 @@ impl Arena {
                 }
             }
 
-            boost_pad_grid = Some(BoostPadGrid::new(&boost_pad_configs, &mutator_config));
+            boost_pad_grid = Some(BoostPadGrid::new(&boost_pad_configs, &config.mutators));
         }
 
         let rng = config.rng_seed.map_or_else(Rng::new, Rng::with_seed);
@@ -127,9 +123,7 @@ impl Arena {
             rng,
             config,
             ball,
-            game_mode,
             boost_pad_grid,
-            mutator_config,
             tick_count: 0,
             cars: Vec::with_capacity(6),
             bullet_world,
@@ -294,10 +288,10 @@ impl Arena {
             .translation
             * BT_TO_UU;
 
-        match self.game_mode {
+        match self.config.game_mode {
             GameMode::Soccar | GameMode::Heatseeker | GameMode::Snowday => {
                 ball_pos.y.abs()
-                    > self.mutator_config.goal_base_threshold_y + self.mutator_config.ball_radius
+                    > self.config.mutators.goal_base_threshold_y + self.config.mutators.ball_radius
             }
             GameMode::Hoops => {
                 if ball_pos.z < consts::goal::HOOPS_GOAL_SCORE_THRESHOLD_Z {
@@ -306,15 +300,14 @@ impl Arena {
                     false
                 }
             }
-            GameMode::Dropshot => ball_pos.z < -self.mutator_config.ball_radius * 1.75,
+            GameMode::Dropshot => ball_pos.z < -self.config.mutators.ball_radius * 1.75,
             GameMode::TheVoid => false,
         }
     }
 
     pub fn reset_to_random_kickoff(&mut self, rng_seed: Option<u64>) {
-        let game_mode = self.game_mode;
-        let kickoff_locs = consts::car::spawn::get_kickoff_spawn_locations(game_mode);
-        let respawn_locs = consts::car::spawn::get_respawn_locations(game_mode);
+        let kickoff_locs = consts::car::spawn::get_kickoff_spawn_locations(self.config.game_mode);
+        let respawn_locs = consts::car::spawn::get_respawn_locations(self.config.game_mode);
 
         let mut kickoff_order_perm = ArrayVec::<usize, 5>::new();
         kickoff_order_perm.extend(0..kickoff_locs.len());
@@ -360,7 +353,7 @@ impl Arena {
                     vel: Vec3A::ZERO,
                     ang_vel: Vec3A::ZERO,
                 },
-                boost: self.mutator_config.car_spawn_boost_amount,
+                boost: self.config.mutators.car_spawn_boost_amount,
                 is_on_ground: true,
                 ..Default::default()
             };
@@ -403,7 +396,7 @@ impl Arena {
         }
 
         let mut ball_state = BallState::DEFAULT;
-        match self.game_mode {
+        match self.config.game_mode {
             GameMode::Heatseeker => {
                 let next_rand = self.rng.bool();
                 let y_sign = f32::from(i8::from(next_rand) * 2 - 1);
@@ -434,14 +427,14 @@ impl Arena {
             idx,
             team,
             &mut self.bullet_world,
-            &self.mutator_config,
+            &self.config.mutators,
             config,
         );
         car.respawn(
             &mut self.bullet_world.bodies_mut()[car.rigid_body_idx],
             &mut self.rng,
-            self.game_mode,
-            self.mutator_config.car_spawn_boost_amount,
+            self.config.game_mode,
+            self.config.mutators.car_spawn_boost_amount,
         );
 
         self.bullet_world.bodies_mut()[car.rigid_body_idx].user_pointer = idx;
@@ -470,14 +463,14 @@ impl Arena {
             car.pre_tick_update(
                 &mut self.bullet_world,
                 &mut self.rng,
-                self.game_mode,
-                &self.mutator_config,
+                self.config.game_mode,
+                &self.config.mutators,
             );
         }
 
         self.ball.pre_tick_update(
             &mut self.bullet_world.bodies_mut()[self.ball.rigid_body_idx],
-            self.game_mode,
+            self.config.game_mode,
         );
 
         self.bullet_world
@@ -528,7 +521,7 @@ impl Arena {
             if let Some(boost_pad_grid) = self.boost_pad_grid.as_mut() {
                 let collected_pad_op = boost_pad_grid.maybe_give_car_boost(
                     &mut car.state,
-                    &self.mutator_config,
+                    &self.config.mutators,
                     self.tick_count,
                 );
 
@@ -542,9 +535,10 @@ impl Arena {
         }
 
         let ball_rb = &mut self.bullet_world.bodies_mut()[self.ball.rigid_body_idx];
-        self.ball.finish_physics_tick(ball_rb, &self.mutator_config);
+        self.ball
+            .finish_physics_tick(ball_rb, &self.config.mutators);
 
-        if self.game_mode == GameMode::Dropshot {
+        if self.config.game_mode == GameMode::Dropshot {
             todo!("Dropshot tile state sync")
         }
 
@@ -569,12 +563,12 @@ impl Arena {
 
     #[inline]
     pub const fn game_mode(&self) -> GameMode {
-        self.game_mode
+        self.config.game_mode
     }
 
     #[inline]
     pub const fn mutator_config(&self) -> &MutatorConfig {
-        &self.mutator_config
+        &self.config.mutators
     }
 
     pub fn set_ball_state(&mut self, ball_state: BallState) {
@@ -634,8 +628,8 @@ impl Arena {
         car.respawn(
             &mut self.bullet_world.bodies_mut()[car.rigid_body_idx],
             &mut self.rng,
-            self.game_mode,
-            self.mutator_config.car_spawn_boost_amount,
+            self.config.game_mode,
+            self.config.mutators.car_spawn_boost_amount,
         );
     }
 
@@ -696,8 +690,9 @@ impl Arena {
         let ball_state = *self.get_ball_state();
         let boost_pad_states = self.get_all_boost_pad_states();
         let boost_pad_configs = self.get_all_boost_pad_configs();
+
         ArenaState {
-            game_mode: self.game_mode,
+            game_mode: self.config.game_mode,
             car_infos,
             car_states,
             ball_state,
@@ -721,15 +716,15 @@ impl Arena {
         if vis_enabled && self.vis_inst.is_none() {
             // Create visualizer
 
-            let mesh_game_mode = match self.game_mode {
+            let mesh_game_mode = match self.config.game_mode {
                 GameMode::Heatseeker | GameMode::Snowday => GameMode::Soccar,
-                _ => self.game_mode,
+                _ => self.config.game_mode,
             };
-            let collision_mesh_files = ARENA_COLLISION_MESH_FILES.read().unwrap();
+            let collision_mesh_files = crate::ARENA_COLLISION_MESH_FILES.read().unwrap();
             let game_mode_mesh_files = &collision_mesh_files.as_ref().unwrap()[&mesh_game_mode];
 
             self.vis_inst = Some(VisInst::new(
-                self.game_mode,
+                self.config.game_mode,
                 game_mode_mesh_files.as_slice(),
             ));
         } else if !vis_enabled && self.vis_inst.is_some() {
@@ -744,7 +739,8 @@ impl Arena {
         let contact_point = manifold_point.pos_world_on_b * BT_TO_UU;
         let contact_normal = manifold_point.normal_world_on_b;
 
-        self.ball.on_world_hit(contact_normal, self.game_mode);
+        self.ball
+            .on_world_hit(contact_normal, self.config.game_mode);
 
         self.events.push(BallHitWorld(BallHitWorldEvent {
             contact_point,
@@ -760,8 +756,8 @@ impl Arena {
     ) {
         self.ball.on_hit(
             &mut self.cars[car_idx],
-            self.game_mode,
-            &self.mutator_config,
+            self.config.game_mode,
+            &self.config.mutators,
             self.tick_count,
         );
 
@@ -842,7 +838,7 @@ impl Arena {
                 continue;
             }
 
-            if self.mutator_config.bump_requires_front_hit {
+            if self.config.mutators.bump_requires_front_hit {
                 let local_point_x = if is_swapped {
                     manifold_point.local_point_b
                 } else {
@@ -857,17 +853,17 @@ impl Arena {
                 }
             }
 
-            let mut is_demo = match self.mutator_config.demo_mode {
+            let mut is_demo = match self.config.mutators.demo_mode {
                 DemoMode::OnContact => true,
                 DemoMode::Disabled => false,
                 DemoMode::Normal => attacker_state.is_supersonic,
             };
-            if is_demo && !self.mutator_config.enable_team_demos {
+            if is_demo && !self.config.mutators.enable_team_demos {
                 is_demo = attacker.team != victim.team;
             }
 
             if is_demo {
-                victim.demolish(self.mutator_config.respawn_delay);
+                victim.demolish(self.config.mutators.respawn_delay);
             } else {
                 let ground_hit = victim_state.is_on_ground;
                 let base_scale = if ground_hit {
@@ -885,7 +881,7 @@ impl Arena {
 
                 let upward_vel_curve = &consts::curves::BUMP_UPWARD_VEL_AMOUNT;
                 let upward_force = upward_vel_curve.get_output(speed_towards_other_car)
-                    * self.mutator_config.bump_force_scale;
+                    * self.config.mutators.bump_force_scale;
                 let bump_impulse = (vel_dir * base_scale) + (hit_up_dir * upward_force);
 
                 victim.vel_impulse_cache += bump_impulse;

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -60,7 +60,7 @@ impl Car {
         config: CarBodyConfig,
     ) -> Self {
         let child_hitbox_shape = BoxShape::new(config.hitbox_size * UU_TO_BT * 0.5);
-        let local_inertia = child_hitbox_shape.calculate_local_intertia(car_consts::MASS_BT);
+        let local_inertia = child_hitbox_shape.calculate_local_intertia(mutator_config.car_mass);
 
         let hitbox_offset = Affine3A {
             matrix3: Mat3A::IDENTITY,
@@ -70,7 +70,7 @@ impl Car {
 
         let collision_shape = CollisionShapes::Compound(compound_shape);
         let mut rb_info =
-            RigidBodyConstructionInfo::new(car_consts::MASS_BT, collision_shape, false);
+            RigidBodyConstructionInfo::new(mutator_config.car_mass, collision_shape, false);
         rb_info.friction = car_consts::BASE_COEFS.friction;
         rb_info.restitution = car_consts::BASE_COEFS.restitution;
         rb_info.start_world_trans = Affine3A::IDENTITY;
@@ -758,7 +758,8 @@ impl Car {
         let forward_speed_uu = {
             let rb = &mut collision_world.bodies_mut()[self.rigid_body_idx];
             if self.state.is_demoed {
-                self.state.demo_respawn_timer = (self.state.demo_respawn_timer - TICK_TIME).max(0.0);
+                self.state.demo_respawn_timer =
+                    (self.state.demo_respawn_timer - TICK_TIME).max(0.0);
                 if self.state.demo_respawn_timer == 0.0 {
                     self.respawn(rb, rng, game_mode, mutator_config.car_spawn_boost_amount);
                 }

--- a/rocketsim/src/sim/collision_mesh_file.rs
+++ b/rocketsim/src/sim/collision_mesh_file.rs
@@ -112,9 +112,12 @@ impl CollisionMeshFile {
         TriangleMesh::new(&self.vertices, &self.indices)
     }
 
+    #[cfg(feature = "vis")]
     pub fn get_vertices(&self) -> &Vec<Vec3A> {
         &self.vertices
     }
+
+    #[cfg(feature = "vis")]
     pub fn get_indices(&self) -> &Vec<usize> {
         &self.indices
     }

--- a/rocketsim/src/sim/mutator_config.rs
+++ b/rocketsim/src/sim/mutator_config.rs
@@ -89,7 +89,7 @@ impl MutatorConfig {
             ball_radius: consts::ball::get_radius(game_mode),
             unlimited_flips: false,
             unlimited_double_jumps: false,
-            recharge_boost_enabled: matches!(game_mode, GameMode::Snowday),
+            recharge_boost_enabled: matches!(game_mode, GameMode::Dropshot),
             recharge_boost_per_second: consts::car::boost::RECHARGE_PER_SECOND,
             recharge_boost_delay: consts::car::boost::RECHARGE_DELAY,
             demo_mode: DemoMode::Normal,


### PR DESCRIPTION
Added `GameMode` and `MutatorConfig` to `ArenaConfig`, so `MutatorConfig` can now be configured for arenas. previously configuing mutators was impossible.

This PR does not allow changing mutators _after_ and arean is created. They can still be read of course.

Fixed:

- `recharge_boost_enabled` was mistakenly enabled for Snowday instead of Dropshot.
- Read car mass from `MutatorConfig` instead of using the constant directly.