### PR TITLE
Fewer dependencies

### DIFF
--- a/rocketsim/Cargo.toml
+++ b/rocketsim/Cargo.toml
@@ -13,7 +13,7 @@ name = "vis"
 required-features = ["vis"]
 
 [dependencies]
-ahash = "0.8.12"
+rustc-hash = "2.1.2"
 arrayvec = "0.7.6"
 byteorder = "1.5.0"
 derive_hash_fast = "0.2.3"

--- a/rocketsim/Cargo.toml
+++ b/rocketsim/Cargo.toml
@@ -17,7 +17,7 @@ ahash = "0.8.12"
 arrayvec = "0.7.6"
 byteorder = "1.5.0"
 derive_hash_fast = "0.2.3"
-env_logger = "0.11.8"
+fern = "0.7.1"
 fastrand = "2.3.0"
 glam = { version = "0.33.0", features = ["debug-glam-assert"] }
 log = "0.4.29"

--- a/rocketsim/src/base.rs
+++ b/rocketsim/src/base.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs,
     io::{Error as IoError, ErrorKind, Result as IoResult},
     path::Path,
@@ -8,7 +7,7 @@ use std::{
 };
 
 use log::{error, info, warn};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 use crate::{
     bullet::collision::shapes::bvh_triangle_mesh_shape::BvhTriangleMeshShape,
@@ -60,7 +59,7 @@ fn init_from_path(collision_meshes_folder: &Path, silent: bool) -> IoResult<()> 
         ));
     }
 
-    let mut mesh_file_map = HashMap::with_hasher(FxBuildHasher::default());
+    let mut mesh_file_map = FxHashMap::default();
 
     for game_mode in GAMEMODES_WITH_UNIQUE_MESHES {
         let folder = collision_meshes_folder.join(game_mode.name());
@@ -110,8 +109,8 @@ pub fn init_from_mem(
 
     // TODO: DropshotTiles::Init();
 
-    let mut arena_collision_shapes = HashMap::with_hasher(FxBuildHasher::default());
-    let mut arena_collision_mesh_files = HashMap::with_hasher(FxBuildHasher::default());
+    let mut arena_collision_shapes = FxHashMap::default();
+    let mut arena_collision_mesh_files = FxHashMap::default();
 
     for (game_mode, byte_mesh_files) in byte_mesh_file_map {
         info!("Loading arena meshes for {}...", game_mode.name());

--- a/rocketsim/src/base.rs
+++ b/rocketsim/src/base.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     io::{Error as IoError, ErrorKind, Result as IoResult},
     path::Path,
@@ -6,8 +7,8 @@ use std::{
     time::Instant,
 };
 
-use ahash::AHashMap;
 use log::{error, info, warn};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::{
     bullet::collision::shapes::bvh_triangle_mesh_shape::BvhTriangleMeshShape,
@@ -23,10 +24,10 @@ use crate::{
 static HAS_INITIALIZED_LOCK: OnceLock<()> = OnceLock::new();
 
 pub(crate) static ARENA_COLLISION_SHAPES: RwLock<
-    Option<AHashMap<GameMode, Vec<Arc<BvhTriangleMeshShape>>>>,
+    Option<FxHashMap<GameMode, Vec<Arc<BvhTriangleMeshShape>>>>,
 > = RwLock::new(None);
 pub(crate) static ARENA_COLLISION_MESH_FILES: RwLock<
-    Option<AHashMap<GameMode, Vec<CollisionMeshFile>>>,
+    Option<FxHashMap<GameMode, Vec<CollisionMeshFile>>>,
 > = RwLock::new(None);
 
 pub fn is_initialized() -> bool {
@@ -59,7 +60,7 @@ fn init_from_path(collision_meshes_folder: &Path, silent: bool) -> IoResult<()> 
         ));
     }
 
-    let mut mesh_file_map = AHashMap::new();
+    let mut mesh_file_map = HashMap::with_hasher(FxBuildHasher::default());
 
     for game_mode in GAMEMODES_WITH_UNIQUE_MESHES {
         let folder = collision_meshes_folder.join(game_mode.name());
@@ -89,7 +90,7 @@ fn init_from_path(collision_meshes_folder: &Path, silent: bool) -> IoResult<()> 
 }
 
 pub fn init_from_mem(
-    byte_mesh_file_map: AHashMap<GameMode, Vec<Vec<u8>>>,
+    byte_mesh_file_map: FxHashMap<GameMode, Vec<Vec<u8>>>,
     silent: bool,
 ) -> IoResult<()> {
     if !silent {
@@ -109,8 +110,8 @@ pub fn init_from_mem(
 
     // TODO: DropshotTiles::Init();
 
-    let mut arena_collision_shapes = AHashMap::new();
-    let mut arena_collision_mesh_files = AHashMap::new();
+    let mut arena_collision_shapes = HashMap::with_hasher(FxBuildHasher::default());
+    let mut arena_collision_mesh_files = HashMap::with_hasher(FxBuildHasher::default());
 
     for (game_mode, byte_mesh_files) in byte_mesh_file_map {
         info!("Loading arena meshes for {}...", game_mode.name());

--- a/rocketsim/src/bullet/collision/broadphase/overlapping_pair_cache.rs
+++ b/rocketsim/src/bullet/collision/broadphase/overlapping_pair_cache.rs
@@ -1,6 +1,6 @@
-use std::mem;
+use std::{collections::HashMap, mem};
 
-use ahash::AHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use super::{BroadphasePair, BroadphaseProxy};
 use crate::bullet::{
@@ -13,7 +13,7 @@ use crate::bullet::{
 
 pub struct HashedOverlappingPairCache {
     overlapping_pair_array: Vec<BroadphasePair>,
-    hash_table: AHashMap<(u32, u32), usize>,
+    hash_table: FxHashMap<(u32, u32), usize>,
 }
 
 impl Default for HashedOverlappingPairCache {
@@ -23,7 +23,7 @@ impl Default for HashedOverlappingPairCache {
 
         Self {
             overlapping_pair_array,
-            hash_table: AHashMap::with_capacity(new_capacity),
+            hash_table: HashMap::with_capacity_and_hasher(new_capacity, FxBuildHasher::default()),
         }
     }
 }

--- a/rocketsim/src/bullet/collision/broadphase/overlapping_pair_cache.rs
+++ b/rocketsim/src/bullet/collision/broadphase/overlapping_pair_cache.rs
@@ -23,7 +23,7 @@ impl Default for HashedOverlappingPairCache {
 
         Self {
             overlapping_pair_array,
-            hash_table: HashMap::with_capacity_and_hasher(new_capacity, FxBuildHasher::default()),
+            hash_table: HashMap::with_capacity_and_hasher(new_capacity, FxBuildHasher),
         }
     }
 }

--- a/rocketsim/src/logging.rs
+++ b/rocketsim/src/logging.rs
@@ -1,12 +1,11 @@
-use std::io::Write;
-
-use env_logger::WriteStyle;
 use log::LevelFilter;
 
 pub fn try_init() -> Result<(), log::SetLoggerError> {
-    env_logger::builder()
-        .format(|buf, record| writeln!(buf, "[RSIM | {}] {}", record.level(), record.args()))
-        .write_style(WriteStyle::Always)
-        .filter(None, LevelFilter::Info)
-        .try_init()
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!("[RSIM | {}] {}", record.level(), message));
+        })
+        .level(LevelFilter::Info)
+        .chain(std::io::stderr())
+        .apply()
 }

--- a/rocketsim/src/sim/game_mode.rs
+++ b/rocketsim/src/sim/game_mode.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum GameMode {
@@ -82,7 +80,7 @@ impl GameMode {
             ]
             .collect(),
             Self::Dropshot => zero_iter![0x7EB0_B2D3, 0x9110_41D2].collect(),
-            _ => HashMap::with_hasher(FxBuildHasher::default()),
+            _ => FxHashMap::default(),
         }
     }
 }

--- a/rocketsim/src/sim/game_mode.rs
+++ b/rocketsim/src/sim/game_mode.rs
@@ -1,4 +1,6 @@
-use ahash::AHashMap;
+use std::collections::HashMap;
+
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum GameMode {
@@ -35,7 +37,7 @@ impl GameMode {
         }
     }
 
-    pub(crate) fn get_hashes(self) -> AHashMap<u32, u32> {
+    pub(crate) fn get_hashes(self) -> FxHashMap<u32, u32> {
         macro_rules! zero_iter {
             ($($i:literal),+) => {
                 [
@@ -80,7 +82,7 @@ impl GameMode {
             ]
             .collect(),
             Self::Dropshot => zero_iter![0x7EB0_B2D3, 0x9110_41D2].collect(),
-            _ => AHashMap::new(),
+            _ => HashMap::with_hasher(FxBuildHasher::default()),
         }
     }
 }

--- a/rocketsim/src/vis/backend/model_set.rs
+++ b/rocketsim/src/vis/backend/model_set.rs
@@ -1,6 +1,6 @@
 use glam::{Vec3, Vec3A};
 use miniquad::{BufferId, BufferSource, BufferType, BufferUsage, RenderingBackend};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 use crate::{shared::rsmath, vis::backend::Model};
 
@@ -14,7 +14,7 @@ pub struct ModelSet {
 
 impl ModelSet {
     pub fn new(models: &[(&str, Model)]) -> Self {
-        let mut index_map = HashMap::with_hasher(FxBuildHasher::default());
+        let mut index_map = FxHashMap::default();
         let mut concat_model = Model::empty();
         for (name_str, model) in models {
             let start_idx = concat_model.num_verts();

--- a/rocketsim/src/vis/backend/model_set.rs
+++ b/rocketsim/src/vis/backend/model_set.rs
@@ -1,20 +1,20 @@
-use ahash::AHashMap;
 use glam::{Vec3, Vec3A};
 use miniquad::{BufferId, BufferSource, BufferType, BufferUsage, RenderingBackend};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::{shared::rsmath, vis::backend::Model};
 
 #[derive(Debug, Clone)]
 pub struct ModelSet {
     /// Maps each model name to the start offset and length in the buffers
-    index_map: AHashMap<String, (usize, usize)>,
+    index_map: FxHashMap<String, (usize, usize)>,
     /// Contains the data from all models concatenated
     concat_model: Model,
 }
 
 impl ModelSet {
     pub fn new(models: &[(&str, Model)]) -> Self {
-        let mut index_map = AHashMap::new();
+        let mut index_map = HashMap::with_hasher(FxBuildHasher::default());
         let mut concat_model = Model::empty();
         for (name_str, model) in models {
             let start_idx = concat_model.num_verts();

--- a/rocketsim/src/vis/backend/texture_set.rs
+++ b/rocketsim/src/vis/backend/texture_set.rs
@@ -1,18 +1,18 @@
-use ahash::AHashMap;
 use miniquad::{
     RawId, RenderingBackend, TextureAccess, TextureFormat, TextureId, TextureParams, TextureSource,
 };
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::vis::backend::Texture;
 
 #[derive(Debug, Clone)]
 pub struct TextureSet {
-    map: AHashMap<String, (Texture, usize)>,
+    map: FxHashMap<String, (Texture, usize)>,
 }
 
 impl TextureSet {
     pub fn new(textures: &[(&str, Texture)]) -> Self {
-        let mut map = AHashMap::new();
+        let mut map = HashMap::with_hasher(FxBuildHasher::default());
         for (name_str, texture) in textures {
             let idx = map.len();
             map.insert(name_str.to_string(), (texture.clone(), idx));

--- a/rocketsim/src/vis/backend/texture_set.rs
+++ b/rocketsim/src/vis/backend/texture_set.rs
@@ -1,7 +1,7 @@
 use miniquad::{
     RawId, RenderingBackend, TextureAccess, TextureFormat, TextureId, TextureParams, TextureSource,
 };
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 use crate::vis::backend::Texture;
 
@@ -12,7 +12,7 @@ pub struct TextureSet {
 
 impl TextureSet {
     pub fn new(textures: &[(&str, Texture)]) -> Self {
-        let mut map = HashMap::with_hasher(FxBuildHasher::default());
+        let mut map = FxHashMap::default();
         for (name_str, texture) in textures {
             let idx = map.len();
             map.insert(name_str.to_string(), (texture.clone(), idx));

--- a/rocketsim/src/vis/backend/vis_renderer.rs
+++ b/rocketsim/src/vis/backend/vis_renderer.rs
@@ -1,6 +1,5 @@
 use std::{sync::Mutex, thread::JoinHandle};
 
-use ahash::AHashMap;
 use glam::{Mat4, Vec2, Vec3, Vec4};
 use miniquad::{
     Bindings, BlendFactor, BlendState, BlendValue, BufferId, BufferLayout, BufferSource,
@@ -9,6 +8,7 @@ use miniquad::{
     UniformDesc, UniformType, UniformsSource, VertexAttribute, VertexFormat, VertexStep, conf,
     window,
 };
+use rustc_hash::FxHashMap;
 
 use crate::vis::backend::{
     Color, ModelSet, ShaderSrc, ShaderSrcType, SharedVisRenderState, SharedWindowEvents,
@@ -121,7 +121,7 @@ pub struct VisRenderer {
     models: ModelSet,
     textures: TextureSet,
 
-    mesh_pipelines: AHashMap<String, Pipeline>,
+    mesh_pipelines: FxHashMap<String, Pipeline>,
     mesh_bindings: Bindings,
     mesh_texture_ids: Vec<TextureId>,
 
@@ -152,8 +152,8 @@ impl VisRenderer {
     ) -> VisRenderer {
         let mut ctx: Box<dyn RenderingBackend> = window::new_rendering_backend();
 
-        let mut mesh_shaders = AHashMap::new();
-        let mut line_shaders = AHashMap::new();
+        let mut mesh_shaders = FxHashMap::default();
+        let mut line_shaders = FxHashMap::default();
         for (shader_name, shader_src) in shader_srcs {
             match shader_src.src_type() {
                 ShaderSrcType::Model => {
@@ -206,7 +206,7 @@ impl VisRenderer {
                 images: vec![TextureId::from_raw_id(RawId::OpenGl(0))],
             };
 
-            let mut pipelines = AHashMap::new();
+            let mut pipelines = FxHashMap::default();
             for (shader_name, shader_id) in mesh_shaders {
                 let params = PipelineParams {
                     depth_test: miniquad::Comparison::LessOrEqual,

--- a/rocketsim/tests/comparison_test/test_result.rs
+++ b/rocketsim/tests/comparison_test/test_result.rs
@@ -1,4 +1,6 @@
-use ahash::AHashMap;
+use std::collections::HashMap;
+
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::comparison_test::{TestResultState, state_compare::StateErrSet};
 
@@ -29,12 +31,13 @@ impl ValueErrorStat {
 #[derive(Debug, Clone)]
 pub struct TestResult {
     pub ticks: Vec<TestResultState>,
-    pub val_err_stats: AHashMap<String, ValueErrorStat>,
+    pub val_err_stats: FxHashMap<String, ValueErrorStat>,
 }
 
 impl TestResult {
     pub fn new(ticks: Vec<TestResultState>) -> Self {
-        let mut val_err_stats: AHashMap<String, ValueErrorStat> = AHashMap::new();
+        let mut val_err_stats: FxHashMap<String, ValueErrorStat> =
+            HashMap::with_hasher(FxBuildHasher::default());
         for tick in &ticks {
             let ball_err = if let Some(ball_err) = &tick.comparison.ball_err {
                 ball_err

--- a/rocketsim/tests/comparison_test/test_result.rs
+++ b/rocketsim/tests/comparison_test/test_result.rs
@@ -36,8 +36,7 @@ pub struct TestResult {
 
 impl TestResult {
     pub fn new(ticks: Vec<TestResultState>) -> Self {
-        let mut val_err_stats: FxHashMap<String, ValueErrorStat> =
-            HashMap::with_hasher(FxBuildHasher::default());
+        let mut val_err_stats: FxHashMap<String, ValueErrorStat> = FxHashMap::default();
         for tick in &ticks {
             let ball_err = if let Some(ball_err) = &tick.comparison.ball_err {
                 ball_err

--- a/rocketsim/tests/test_all.rs
+++ b/rocketsim/tests/test_all.rs
@@ -4,16 +4,16 @@ mod comparison_test;
 
 use std::sync::OnceLock;
 
-use ahash::AHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use test_case::test_matrix;
 
 use crate::comparison_test::*;
 
 const FAIL_ERROR_THRESH: f32 = 0.5;
 
-fn init_for_test() -> &'static AHashMap<String, TestCase> {
+fn init_for_test() -> &'static FxHashMap<String, TestCase> {
     static INIT: OnceLock<()> = OnceLock::new();
-    static CASES: OnceLock<AHashMap<String, TestCase>> = OnceLock::new();
+    static CASES: OnceLock<FxHashMap<String, TestCase>> = OnceLock::new();
 
     INIT.get_or_init(|| {
         rocketsim::init("../collision_meshes", false).unwrap();


### PR DESCRIPTION
- Replaced env_logger with fern (identical output)
- Replace ahash with rustc-hash (seems to be marginally faster too which is nice)
- Compile time went from 9.995s to 6.162s

<table>
<tr>
<td> Before (default features) </td> <td> After (default features) </td>
</tr>
<tr>
<td>

```
rocketsim v0.2.0
├── ahash v0.8.12
│   ├── cfg-if v1.0.4
│   ├── getrandom v0.3.4
│   │   ├── cfg-if v1.0.4
│   │   └── libc v0.2.186
│   ├── once_cell v1.21.4
│   └── zerocopy v0.8.50
│       └── zerocopy-derive v0.8.50 (proc-macro)
│           ├── proc-macro2 v1.0.106
│           │   └── unicode-ident v1.0.24
│           ├── quote v1.0.45
│           │   └── proc-macro2 v1.0.106 (*)
│           └── syn v2.0.117
│               ├── proc-macro2 v1.0.106 (*)
│               ├── quote v1.0.45 (*)
│               └── unicode-ident v1.0.24
├── arrayvec v0.7.6
├── byteorder v1.5.0
├── derive_hash_fast v0.2.3
├── env_logger v0.11.10
│   ├── anstream v1.0.0
│   │   ├── anstyle v1.0.14
│   │   ├── anstyle-parse v1.0.0
│   │   │   └── utf8parse v0.2.2
│   │   ├── anstyle-query v1.1.5
│   │   ├── colorchoice v1.0.5
│   │   ├── is_terminal_polyfill v1.70.2
│   │   └── utf8parse v0.2.2
│   ├── anstyle v1.0.14
│   ├── env_filter v1.0.1
│   │   ├── log v0.4.32
│   │   └── regex v1.12.4
│   │       ├── aho-corasick v1.1.4
│   │       │   └── memchr v2.8.1
│   │       ├── memchr v2.8.1
│   │       ├── regex-automata v0.4.14
│   │       │   ├── aho-corasick v1.1.4 (*)
│   │       │   ├── memchr v2.8.1
│   │       │   └── regex-syntax v0.8.11
│   │       └── regex-syntax v0.8.11
│   ├── jiff v0.2.28
│   └── log v0.4.32
├── fastrand v2.4.1
├── glam v0.33.1
├── log v0.4.32
├── rocketsim_derive v0.1.0 (proc-macro)
│   ├── quote v1.0.45 (*)
│   └── syn v2.0.117 (*)
└── zerocopy v0.8.50 (*)
```

</td>
<td>

```
rocketsim v0.2.0
├── arrayvec v0.7.6
├── byteorder v1.5.0
├── derive_hash_fast v0.2.3
├── fastrand v2.3.0
├── fern v0.7.1
│   └── log v0.4.29
├── glam v0.33.1
├── log v0.4.29
├── rocketsim_derive v0.1.0 (proc-macro)
│   ├── quote v1.0.45
│   │   └── proc-macro2 v1.0.106
│   │       └── unicode-ident v1.0.24
│   └── syn v2.0.117
│       ├── proc-macro2 v1.0.106 (*)
│       ├── quote v1.0.45 (*)
│       └── unicode-ident v1.0.24
├── rustc-hash v2.1.2
└── zerocopy v0.8.39
    └── zerocopy-derive v0.8.39 (proc-macro)
        ├── proc-macro2 v1.0.106 (*)
        ├── quote v1.0.45 (*)
        └── syn v2.0.117 (*)
```

</td>
</tr>
</table>