### PR TITLE
Fix car hitbox collision parity

### DIFF
--- a/rocketsim/src/bullet/collision/broadphase/grid_broadphase.rs
+++ b/rocketsim/src/bullet/collision/broadphase/grid_broadphase.rs
@@ -213,8 +213,9 @@ impl GridBroadphase {
 
             self.handles[proxy_idx].cell_idx = new_idx;
             if new_idx != old_idx {
+                let old_indices = self.handles[proxy_idx].indices;
                 self.cell_grid
-                    .update_cells_dynamic::<false>(proxy_idx, new_indices);
+                    .update_cells_dynamic::<false>(proxy_idx, old_indices);
                 self.handles[proxy_idx].indices = new_indices;
                 self.cell_grid
                     .update_cells_dynamic::<true>(proxy_idx, new_indices);

--- a/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
+++ b/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
@@ -462,10 +462,16 @@ fn box_box_sat(obb1: &Obb, r1t: &Mat3A, obb2: &Obb) -> Option<Hit> {
     let p = obb2.center - obb1.center;
     let pp = r1t * p;
 
-    // Rij is R1'*R2, i.e. the relative rotation between R1 and R2
+    // Rij is R1'*R2, i.e. the relative rotation between R1 and R2.
+    // `Mat3A` is column-major, so `rij_cols[j][i]` is Bullet's R(i + 1, j + 1).
     let rij = r1t * obb2.axis;
+    let rij_cols = [rij.x_axis, rij.y_axis, rij.z_axis];
 
-    let mut q = rij.transpose().abs();
+    let q_cols_mat = rij.abs();
+    let mut q_cols = [q_cols_mat.x_axis, q_cols_mat.y_axis, q_cols_mat.z_axis];
+
+    let q_rows_mat = q_cols_mat.transpose();
+    let q_rows = [q_rows_mat.x_axis, q_rows_mat.y_axis, q_rows_mat.z_axis];
 
     // for all 15 possible separating axes:
     //   * see if the axis separates the boxes. if so, return 0.
@@ -501,59 +507,33 @@ fn box_box_sat(obb1: &Obb, r1t: &Mat3A, obb2: &Obb) -> Option<Hit> {
     };
 
     // separating axis = u1,u2,u3
-    if !tst(
-        pp.x,
-        obb1.extent.x + obb2.extent.dot(q.x_axis),
-        obb1.axis.x_axis,
-        1,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.y,
-        obb1.extent.y + obb2.extent.dot(q.y_axis),
-        obb1.axis.y_axis,
-        2,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.z,
-        obb1.extent.z + obb2.extent.dot(q.z_axis),
-        obb1.axis.z_axis,
-        3,
-    ) {
-        return None;
+    for (i, normal) in [obb1.axis.x_axis, obb1.axis.y_axis, obb1.axis.z_axis]
+        .into_iter()
+        .enumerate()
+    {
+        if !tst(
+            pp[i],
+            obb1.extent[i] + obb2.extent.dot(q_rows[i]),
+            normal,
+            i + 1,
+        ) {
+            return None;
+        }
     }
 
     // separating axis = v1,v2,v3
-    if !tst(
-        obb2.axis.x_axis.dot(p),
-        obb1.extent.dot(q.x_axis) + obb2.extent.x,
-        obb2.axis.x_axis,
-        4,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        obb2.axis.y_axis.dot(p),
-        obb1.extent.dot(q.y_axis) + obb2.extent.y,
-        obb2.axis.y_axis,
-        5,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        obb2.axis.z_axis.dot(p),
-        obb1.extent.dot(q.z_axis) + obb2.extent.z,
-        obb2.axis.z_axis,
-        6,
-    ) {
-        return None;
+    for (i, normal) in [obb2.axis.x_axis, obb2.axis.y_axis, obb2.axis.z_axis]
+        .into_iter()
+        .enumerate()
+    {
+        if !tst(
+            normal.dot(p),
+            obb1.extent.dot(q_cols[i]) + obb2.extent[i],
+            normal,
+            i + 4,
+        ) {
+            return None;
+        }
     }
 
     // note: cross product axes need to be scaled when s is computed.
@@ -579,119 +559,30 @@ fn box_box_sat(obb1: &Obb, r1t: &Mat3A, obb2: &Obb) -> Option<Hit> {
         true
     };
 
-    q.x_axis += FUDGE_2;
-    q.y_axis += FUDGE_2;
-    q.z_axis += FUDGE_2;
-
-    // separating axis = u1 x (v1,v2,v3)
-    if !tst(
-        pp.z * rij.y_axis.x - pp.y * rij.z_axis.x,
-        obb1.extent.y * q.x_axis.z
-            + obb1.extent.z * q.x_axis.y
-            + obb2.extent.y * q.z_axis.x
-            + obb2.extent.z * q.y_axis.x,
-        Vec3A::new(0.0, -rij.z_axis.x, rij.y_axis.x),
-        7,
-    ) {
-        return None;
+    for col in &mut q_cols {
+        *col += FUDGE_2;
     }
+    let q_rows_mat = Mat3A::from_cols(q_cols[0], q_cols[1], q_cols[2]).transpose();
+    let q_rows = [q_rows_mat.x_axis, q_rows_mat.y_axis, q_rows_mat.z_axis];
 
-    if !tst(
-        pp.z * rij.y_axis.y - pp.y * rij.z_axis.y,
-        obb1.extent.y * q.y_axis.z
-            + obb1.extent.z * q.y_axis.y
-            + obb2.extent.x * q.z_axis.x
-            + obb2.extent.z * q.x_axis.x,
-        Vec3A::new(0.0, -rij.z_axis.y, rij.y_axis.y),
-        8,
-    ) {
-        return None;
-    }
+    // separating axis = u_i x v_j
+    for (i, axis) in [Vec3A::X, Vec3A::Y, Vec3A::Z].into_iter().enumerate() {
+        let i1 = (i + 1) % 3;
+        let i2 = (i + 2) % 3;
 
-    if !tst(
-        pp.z * rij.y_axis.z - pp.y * rij.z_axis.z,
-        obb1.extent.y * q.z_axis.z
-            + obb1.extent.z * q.z_axis.y
-            + obb2.extent.x * q.y_axis.x
-            + obb2.extent.y * q.x_axis.x,
-        Vec3A::new(0.0, -rij.z_axis.z, rij.y_axis.z),
-        9,
-    ) {
-        return None;
-    }
+        for (j, r_col) in rij_cols.into_iter().enumerate() {
+            let j1 = (j + 1) % 3;
+            let j2 = (j + 2) % 3;
+            let n = axis.cross(r_col);
+            let expr2 = obb1.extent[i1] * q_cols[j][i2]
+                + obb1.extent[i2] * q_cols[j][i1]
+                + obb2.extent[j1] * q_rows[i][j2]
+                + obb2.extent[j2] * q_rows[i][j1];
 
-    // separating axis = u2 x (v1,v2,v3)
-    if !tst(
-        pp.x * rij.z_axis.x - pp.z * rij.x_axis.x,
-        obb1.extent.x * q.x_axis.z
-            + obb1.extent.z * q.x_axis.x
-            + obb2.extent.y * q.z_axis.y
-            + obb2.extent.z * q.y_axis.y,
-        Vec3A::new(rij.z_axis.x, 0.0, -rij.x_axis.x),
-        10,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.x * rij.z_axis.y - pp.z * rij.x_axis.y,
-        obb1.extent.x * q.y_axis.z
-            + obb1.extent.z * q.y_axis.x
-            + obb2.extent.x * q.z_axis.y
-            + obb2.extent.z * q.x_axis.y,
-        Vec3A::new(rij.z_axis.y, 0.0, -rij.x_axis.y),
-        11,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.x * rij.z_axis.z - pp.z * rij.x_axis.z,
-        obb1.extent.x * q.z_axis.z
-            + obb1.extent.z * q.z_axis.x
-            + obb2.extent.x * q.y_axis.y
-            + obb2.extent.y * q.x_axis.y,
-        Vec3A::new(rij.z_axis.z, 0.0, -rij.x_axis.z),
-        12,
-    ) {
-        return None;
-    }
-
-    // separating axis = u3 x (v1,v2,v3)
-    if !tst(
-        pp.y * rij.x_axis.x - pp.x * rij.y_axis.x,
-        obb1.extent.x * q.x_axis.y
-            + obb1.extent.y * q.x_axis.x
-            + obb2.extent.y * q.z_axis.z
-            + obb2.extent.z * q.y_axis.z,
-        Vec3A::new(-rij.y_axis.x, rij.x_axis.x, 0.0),
-        13,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.y * rij.x_axis.y - pp.x * rij.y_axis.y,
-        obb1.extent.x * q.y_axis.y
-            + obb1.extent.y * q.y_axis.x
-            + obb2.extent.x * q.z_axis.z
-            + obb2.extent.z * q.x_axis.z,
-        Vec3A::new(-rij.y_axis.y, rij.x_axis.y, 0.0),
-        14,
-    ) {
-        return None;
-    }
-
-    if !tst(
-        pp.y * rij.x_axis.z - pp.x * rij.y_axis.z,
-        obb1.extent.x * q.z_axis.y
-            + obb1.extent.y * q.z_axis.x
-            + obb2.extent.x * q.y_axis.z
-            + obb2.extent.y * q.x_axis.z,
-        Vec3A::new(-rij.y_axis.z, rij.x_axis.z, 0.0),
-        15,
-    ) {
-        return None;
+            if !tst(pp.dot(n), expr2, n, 7 + i * 3 + j) {
+                return None;
+            }
+        }
     }
 
     if code == 0 {
@@ -700,7 +591,7 @@ fn box_box_sat(obb1: &Obb, r1t: &Mat3A, obb2: &Obb) -> Option<Hit> {
 
     // if we get to this point, the boxes interpenetrate. compute the normal
     // in global coordinates.
-    let mut normal = normal_r.unwrap_or_else(|| r1t * normal_c);
+    let mut normal = normal_r.unwrap_or_else(|| obb1.axis * normal_c);
     if invert_normal {
         normal = -normal;
     }
@@ -712,4 +603,41 @@ fn box_box_sat(obb1: &Obb, r1t: &Mat3A, obb2: &Obb) -> Option<Hit> {
         normal,
         axis_idx: code,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use glam::{Mat3A, Vec3A};
+
+    use super::{Obb, box_box_sat};
+    use crate::{CarBodyConfig, consts::UU_TO_BT};
+
+    fn octane_obb(pos_uu: Vec3A, rot_mat: Mat3A) -> Obb {
+        let config = CarBodyConfig::OCTANE;
+        Obb::new(
+            (pos_uu + rot_mat * config.hitbox_pos_offset) * UU_TO_BT,
+            rot_mat,
+            config.hitbox_size * UU_TO_BT * 0.5,
+        )
+    }
+
+    #[test]
+    fn rotated_offset_octane_hitboxes_overlap() {
+        let car_a_rot = Mat3A::from_cols(
+            Vec3A::new(-0.197_008_49, -0.710_327_74, -0.675_738_2),
+            Vec3A::new(-0.328_847_1, -0.592_099, 0.735_586_46),
+            Vec3A::new(0.924_127_6, -0.364_699_04, 0.113_941_91),
+        );
+        let car_b_rot = Mat3A::from_cols(
+            Vec3A::new(0.031_831_503, 0.093_713_61, 0.995_090_25),
+            Vec3A::new(0.937_990_5, -0.346_187_98, 0.003_024_293_8),
+            Vec3A::new(0.344_967_37, 0.933_385_7, -0.098_937_63),
+        );
+
+        let car_a = octane_obb(Vec3A::new(161.537_67, -40.835_064, 366.293_03), car_a_rot);
+        let car_b = octane_obb(Vec3A::new(148.926_6, -160.566_18, 400.462_95), car_b_rot);
+
+        let hit = box_box_sat(&car_a, &car_a.axis.transpose(), &car_b);
+        assert!(hit.is_some());
+    }
 }

--- a/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
+++ b/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
@@ -286,11 +286,7 @@ impl<T: ContactAddedCallback> BoxBoxDetector<'_, T> {
             -hit.normal
         };
 
-        let nr = Vec3A::new(
-            normal_2.dot(r2t_axes[0]),
-            normal_2.dot(r2t_axes[1]),
-            normal_2.dot(r2t_axes[2]),
-        );
+        let nr = r2t.mul_transpose_vec3a(normal_2);
         let anr = nr.abs();
 
         // find the largest compontent of anr: this corresponds to the normal

--- a/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
+++ b/rocketsim/src/bullet/collision/dispatch/box_box_detector.rs
@@ -197,27 +197,21 @@ impl<T: ContactAddedCallback> BoxBoxDetector<'_, T> {
         transform_a: Affine3A,
         transform_b: Affine3A,
     ) -> Option<PersistentManifold> {
-        let xforma = transform_a.matrix3.transpose();
-        let xformb = transform_b.matrix3.transpose();
+        let axis_a = transform_a.matrix3;
+        let axis_b = transform_b.matrix3;
+        let axis_a_inv = axis_a.transpose();
 
-        let side1 = self.box1.get_half_extents();
-        let side2 = self.box2.get_half_extents();
+        let side1 = self.box1.get_half_extents() + self.box1.get_margin();
+        let side2 = self.box2.get_half_extents() + self.box2.get_margin();
 
-        let obb1 = Obb::new(transform_a.translation, xforma, side1);
-        let obb2 = Obb::new(transform_b.translation, xformb, side2);
+        let obb1 = Obb::new(transform_a.translation, axis_a, side1);
+        let obb2 = Obb::new(transform_b.translation, axis_b, side2);
 
-        let hit = box_box_sat(&obb1, &transform_a.matrix3, &obb2)?;
+        let hit = box_box_sat(&obb1, &axis_a_inv, &obb2)?;
 
         let mut manifold = PersistentManifold::new(self.col1, self.col2);
 
-        self.compute_contact_points(
-            &obb1,
-            &transform_a.matrix3,
-            &obb2,
-            &transform_b.matrix3,
-            &hit,
-            &mut manifold,
-        );
+        self.compute_contact_points(&obb1, &axis_a, &obb2, &axis_b, &hit, &mut manifold);
 
         if manifold.point_cache.is_empty() {
             return None;
@@ -292,7 +286,11 @@ impl<T: ContactAddedCallback> BoxBoxDetector<'_, T> {
             -hit.normal
         };
 
-        let nr = obb2.axis * normal_2;
+        let nr = Vec3A::new(
+            normal_2.dot(r2t_axes[0]),
+            normal_2.dot(r2t_axes[1]),
+            normal_2.dot(r2t_axes[2]),
+        );
         let anr = nr.abs();
 
         // find the largest compontent of anr: this corresponds to the normal
@@ -431,7 +429,7 @@ impl<T: ContactAddedCallback> BoxBoxDetector<'_, T> {
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
             .unwrap();
 
-        let iret = cull_points2(&ret[..cnum], maxc, i1);
+        let iret = cull_points2(&ret[..cnum], i1, maxc);
 
         for idx in iret.into_iter().take(maxc) {
             let pos_in_world = point[idx] + obb1.center;

--- a/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
+++ b/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
@@ -38,6 +38,7 @@ impl CollisionDispatcher {
                         &RigidBodyWrapper {
                             obj: col_obj_b,
                             world_trans: *col_obj_b.get_world_trans(),
+                            child_shape_override: None,
                         },
                         col_obj_a,
                         plane,
@@ -58,6 +59,7 @@ impl CollisionDispatcher {
                         &RigidBodyWrapper {
                             obj: col_obj_a,
                             world_trans: *col_obj_a.get_world_trans(),
+                            child_shape_override: None,
                         },
                         col_obj_b,
                         plane,
@@ -84,6 +86,7 @@ impl CollisionDispatcher {
                     &RigidBodyWrapper {
                         obj: col_obj_a,
                         world_trans: *col_obj_a.get_world_trans(),
+                        child_shape_override: None,
                     },
                     col_obj_b,
                     contact_added_callback,
@@ -149,6 +152,7 @@ impl CollisionDispatcher {
                         &RigidBodyWrapper {
                             obj: col_obj_a,
                             world_trans: *col_obj_a.get_world_trans(),
+                            child_shape_override: None,
                         },
                         col_obj_b,
                         plane,
@@ -173,6 +177,7 @@ impl CollisionDispatcher {
                     &RigidBodyWrapper {
                         obj: col_obj_a,
                         world_trans: *col_obj_a.get_world_trans(),
+                        child_shape_override: None,
                     },
                     col_obj_b,
                     contact_added_callback,

--- a/rocketsim/src/bullet/collision/dispatch/collision_obj_wrapper.rs
+++ b/rocketsim/src/bullet/collision/dispatch/collision_obj_wrapper.rs
@@ -1,8 +1,37 @@
 use glam::Affine3A;
 
-use crate::bullet::dynamics::rigid_body::RigidBody;
+use crate::{
+    bullet::{
+        collision::shapes::{box_shape::BoxShape, collision_shape::CollisionShapes},
+        dynamics::rigid_body::RigidBody,
+    },
+    shared::Aabb,
+};
 
 pub struct RigidBodyWrapper<'a> {
     pub obj: &'a RigidBody,
     pub world_trans: Affine3A,
+    pub child_shape_override: Option<&'a BoxShape>,
+}
+
+impl RigidBodyWrapper<'_> {
+    pub fn get_collision_shape(&self) -> &CollisionShapes {
+        self.obj.get_collision_shape()
+    }
+
+    pub fn get_aabb(&self) -> Aabb {
+        if let Some(child_shape) = self.child_shape_override {
+            child_shape.get_aabb(&self.world_trans)
+        } else {
+            self.get_collision_shape().get_aabb(&self.world_trans)
+        }
+    }
+
+    pub fn local_get_supporting_vertex(&self, vec: glam::Vec3A) -> glam::Vec3A {
+        if let Some(child_shape) = self.child_shape_override {
+            child_shape.local_get_supporting_vertex(vec)
+        } else {
+            self.get_collision_shape().local_get_supporting_vertex(vec)
+        }
+    }
 }

--- a/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
@@ -49,6 +49,7 @@ impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> 
         }
 
         let half_extents = self.box_shape.get_half_extents();
+        let contact_margin = self.box_shape.get_margin() + self.manifold.contact_breaking_threshold;
 
         let world_to_box = self.convex_obj.world_trans.inverse();
         let tri_to_world = self.tri_obj.get_world_trans();
@@ -77,12 +78,13 @@ impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> 
                 .max(tri_verts_rel[1][i])
                 .max(tri_verts_rel[2][i]);
 
-            if tri_max < -half_extents[i] || tri_min > half_extents[i] {
+            let axis_extent = half_extents[i] + contact_margin;
+            if tri_max < -axis_extent || tri_min > axis_extent {
                 return;
             }
 
-            let p_neg = tri_max + half_extents[i];
-            let p_pos = half_extents[i] - tri_min;
+            let p_neg = tri_max + axis_extent;
+            let p_pos = axis_extent - tri_min;
             let (penetration, side) = if p_neg < p_pos {
                 (p_neg, -1.0)
             } else {
@@ -104,7 +106,7 @@ impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> 
         let tri_normal = tri_edges_rel[0].cross(tri_edges_rel[1]);
         if let Some(norm_axis) = tri_normal.try_normalize() {
             let plane_dist = norm_axis.dot(tri_verts_rel[0]);
-            let proj_radius = half_extents.dot(norm_axis.abs());
+            let proj_radius = half_extents.dot(norm_axis.abs()) + contact_margin;
 
             if plane_dist.abs() > proj_radius {
                 return;
@@ -138,7 +140,7 @@ impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> 
                         norm_axis.dot(tri_verts_rel[2]),
                     );
                     let (tri_min, tri_max) = (p.min_element(), p.max_element());
-                    let proj_radius = half_extents.dot(norm_axis.abs());
+                    let proj_radius = half_extents.dot(norm_axis.abs()) + contact_margin;
 
                     if tri_max < -proj_radius || tri_min > proj_radius {
                         return;

--- a/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
@@ -304,6 +304,7 @@ pub fn process_collision<T: ContactAddedCallback>(
     let compound_obj_wrap = RigidBodyWrapper {
         obj: compound_obj,
         world_trans: new_child_world_trans,
+        child_shape_override: Some(box_shape),
     };
 
     match other_col_shape {

--- a/rocketsim/src/bullet/collision/dispatch/convex_plane_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/convex_plane_collision_alg.rs
@@ -15,8 +15,7 @@ pub fn process_collision<T: ContactAddedCallback>(
     plane_shape: &StaticPlaneShape,
     contact_added_callback: &mut T,
 ) -> Option<PersistentManifold> {
-    let col_shape = convex_obj.obj.get_collision_shape();
-    let convex_aabb = col_shape.get_aabb(&convex_obj.world_trans);
+    let convex_aabb = convex_obj.get_aabb();
     if !convex_aabb.intersects(&plane_shape.aabb_cache) {
         return None;
     }
@@ -31,7 +30,7 @@ pub fn process_collision<T: ContactAddedCallback>(
             - plane_trans.translation,
     };
 
-    let vtx = col_shape.local_get_supporting_vertex(plane_in_convex * -plane_normal);
+    let vtx = convex_obj.local_get_supporting_vertex(plane_in_convex * -plane_normal);
     let vtx_in_plane = convex_in_plane_trans.transform_point3a(vtx);
     let distance = plane_normal.dot(vtx_in_plane);
 

--- a/rocketsim/src/bullet/collision/dispatch/obb_obb_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/obb_obb_collision_alg.rs
@@ -25,13 +25,13 @@ pub fn process_collision<T: ContactAddedCallback>(
     let child_a_trans = &compound_a_shape.child_trans;
     let child_a_world_trans = org_0_trans * child_a_trans;
 
-    let child_b_trans = &compound_a_shape.child_trans;
+    let child_b_trans = &compound_b_shape.child_trans;
     let child_b_world_trans = org_1_trans * child_b_trans;
 
     let mut detector = BoxBoxDetector {
         box1: &compound_a_shape.child_shape,
         col1: compound_a_obj,
-        box2: &compound_a_shape.child_shape,
+        box2: &compound_b_shape.child_shape,
         col2: compound_b_obj,
         contact_added_callback,
     };

--- a/rocketsim/src/bullet/collision/dispatch/sphere_obb_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/sphere_obb_collision_alg.rs
@@ -9,6 +9,31 @@ use crate::bullet::{
     linear_math::AffineExt,
 };
 
+fn get_sphere_penetration(box_extents: Vec3A, sphere_from_local: Vec3A) -> (f32, Vec3A, Vec3A) {
+    let mut min_dist = box_extents.x - sphere_from_local.x;
+    let mut closest = sphere_from_local;
+    closest.x = box_extents.x;
+    let mut normal = Vec3A::X;
+
+    let mut test_face = |face_dist: f32, axis: usize, sign: f32| {
+        if face_dist < min_dist {
+            min_dist = face_dist;
+            closest = sphere_from_local;
+            closest[axis] = box_extents[axis] * sign;
+            normal = Vec3A::ZERO;
+            normal[axis] = sign;
+        }
+    };
+
+    test_face(box_extents.x + sphere_from_local.x, 0, -1.0);
+    test_face(box_extents.y - sphere_from_local.y, 1, 1.0);
+    test_face(box_extents.y + sphere_from_local.y, 1, -1.0);
+    test_face(box_extents.z - sphere_from_local.z, 2, 1.0);
+    test_face(box_extents.z + sphere_from_local.z, 2, -1.0);
+
+    (min_dist, closest, normal)
+}
+
 pub fn process_collision<T: ContactAddedCallback>(
     sphere_obj: &RigidBody,
     sphere_shape: &SphereShape,
@@ -34,31 +59,35 @@ pub fn process_collision<T: ContactAddedCallback>(
 
     let sphere_from_local = new_child_world_trans.inv_x_form(sphere_trans.translation);
 
-    let closest = sphere_from_local.clamp(-box_extents, box_extents);
-    let delta = sphere_from_local - closest;
+    let mut closest = sphere_from_local.clamp(-box_extents, box_extents);
+    let mut delta = sphere_from_local - closest;
     let dist_sq = delta.length_squared();
 
     let radius = sphere_shape.get_radius();
     let box_margin = box_shape.get_margin();
-    if dist_sq >= (radius + box_margin).powi(2) {
+
+    let mut manifold = PersistentManifold::new(sphere_obj, obb_obj);
+    let intersection_dist = radius + box_margin;
+    let contact_dist = intersection_dist + manifold.contact_breaking_threshold;
+    if dist_sq > contact_dist * contact_dist {
         return None;
     }
 
-    let dist = dist_sq.sqrt();
-    let normal = if dist > f32::EPSILON {
-        delta / dist
+    let mut dist;
+    if dist_sq > f32::EPSILON {
+        dist = dist_sq.sqrt();
+        delta /= dist;
     } else {
-        Vec3A::X
+        (dist, closest, delta) = get_sphere_penetration(box_extents, sphere_from_local);
+        dist *= -1.0;
     };
 
-    let normal_on_box = new_child_world_trans.transform_vector3a(normal);
+    let normal_on_box = new_child_world_trans.transform_vector3a(delta);
     let point_on_box = new_child_world_trans.transform_point3a(closest);
-    let depth = dist - radius - box_margin;
+    let depth = dist - intersection_dist;
 
     // This is the official contact point on the box
     let point_on_box_plus_margin = point_on_box + (normal_on_box * box_margin);
-
-    let mut manifold = PersistentManifold::new(sphere_obj, obb_obj);
     manifold.add_contact_point(
         sphere_obj,
         obb_obj,

--- a/rocketsim/src/bullet/collision/shapes/box_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/box_shape.rs
@@ -38,7 +38,7 @@ impl BoxShape {
     }
 
     pub fn calculate_local_intertia(&self, mass: f32) -> Vec3A {
-        let l = 2.0 * self.get_half_extents();
+        let l = 2.0 * (self.get_half_extents() + self.get_margin());
         let yxx = l.yxx();
         let zzy = l.zzy();
 
@@ -46,6 +46,6 @@ impl BoxShape {
     }
 
     pub fn local_get_supporting_vertex(&self, vec: Vec3A) -> Vec3A {
-        self.get_half_extents() * vec.signum()
+        (self.get_half_extents() + self.get_margin()) * Vec3A::ONE.copysign(vec)
     }
 }

--- a/rocketsim/src/bullet/collision/shapes/compound_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/compound_shape.rs
@@ -140,6 +140,10 @@ impl CompoundShape {
             return;
         }
 
+        if tenter <= 0.0 {
+            return;
+        }
+
         let mut hit_normal = Vec3A::ZERO;
         hit_normal[hit_axis] = -dir[hit_axis].signum();
 

--- a/rocketsim/src/bullet/dynamics/vehicle/wheel_info.rs
+++ b/rocketsim/src/bullet/dynamics/vehicle/wheel_info.rs
@@ -241,11 +241,10 @@ impl WheelInfo {
 
         let mut wheels_suspension_force =
             force - (damping_vel_scale * raycast_info.suspension_relative_vel);
+        wheels_suspension_force *= self.suspsension_force_scale;
         if wheels_suspension_force <= 0.0 {
             return;
         }
-
-        wheels_suspension_force *= self.suspsension_force_scale;
         let base_force_scale = wheels_suspension_force * delta_time + self.extra_pushback;
         let contact_point_offset = raycast_info.contact_point - cb.get_world_trans().translation;
 

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -959,9 +959,10 @@ impl Arena {
                 let upward_force = upward_vel_curve.get_output(speed_towards_other_car)
                     * self.config.mutators.bump_force_scale;
                 let bump_impulse = (vel_dir * base_scale) + (hit_up_dir * upward_force);
-
-                victim.vel_impulse_cache += bump_impulse;
+                victim.vel_impulse_cache += bump_impulse * UU_TO_BT;
             }
+
+            attacker.state.bump_cooldown_timer = self.config.mutators.bump_cooldown_time;
 
             let contact_point = if is_swapped {
                 manifold_point.pos_world_on_b

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -914,19 +914,17 @@ impl Arena {
                 continue;
             }
 
-            if self.config.mutators.bump_requires_front_hit {
-                let local_point_x = if is_swapped {
-                    manifold_point.local_point_b
-                } else {
-                    manifold_point.local_point_a
-                }
-                .x * BT_TO_UU;
+            let local_point_x = if is_swapped {
+                manifold_point.local_point_b
+            } else {
+                manifold_point.local_point_a
+            }
+            .x;
 
-                let hit_with_bumper = local_point_x > consts::car::bump::MIN_FORWARD_DIST;
-                if !hit_with_bumper {
-                    // Didn't hit with bumper
-                    continue;
-                }
+            let hit_with_bumper = local_point_x * BT_TO_UU > consts::car::bump::MIN_FORWARD_DIST;
+            if !hit_with_bumper {
+                // Didn't hit with bumper
+                continue;
             }
 
             let mut is_demo = match self.config.mutators.demo_mode {

--- a/rocketsim/src/sim/ball/base.rs
+++ b/rocketsim/src/sim/ball/base.rs
@@ -128,6 +128,7 @@ impl Ball {
             rb.set_activation_state(ActivationState::Active);
         }
 
+        self.vel_impulse_cache = Vec3A::ZERO;
         self.state = state;
     }
 

--- a/rocketsim/src/sim/ball/base.rs
+++ b/rocketsim/src/sim/ball/base.rs
@@ -288,7 +288,7 @@ impl Ball {
                 consts::ball::car_hit_impulse::Z_SCALE_NORMAL
             };
 
-            let mut hit_dir = rel_pos * Vec3A::new(1.0, 1.0, z_scale).normalize_or_zero();
+            let mut hit_dir = (rel_pos * Vec3A::new(1.0, 1.0, z_scale)).normalize_or_zero();
             let forward_dir_adjustment = car_forward
                 * hit_dir.dot(car_forward)
                 * const { 1.0 - consts::ball::car_hit_impulse::FORWARD_SCALE };

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -751,7 +751,7 @@ impl Car {
             self.bullet_vehicle.get_num_wheels() == 4 || self.bullet_vehicle.get_num_wheels() == 3
         );
 
-        let forward_speed_uu = {
+        {
             let rb = &mut collision_world.bodies_mut()[self.rigid_body_idx];
             if self.state.is_demoed {
                 self.state.demo_respawn_timer =
@@ -768,13 +768,14 @@ impl Car {
             rb.force_activate();
             rb.collision_flags &= !(CollisionFlags::NoContactResponse as u8);
             self.state.controls = self.state.controls.clamp();
-
-            rb.get_forward_speed() * BT_TO_UU
-        };
+        }
 
         // Do first part of the btVehicleRL update (update wheel transforms, do traces, calculate friction impulses)
         self.bullet_vehicle
             .update_vehicle_first(collision_world, TICK_TIME);
+
+        let forward_speed_uu =
+            collision_world.bodies()[self.rigid_body_idx].get_forward_speed() * BT_TO_UU;
 
         let jump_pressed = self.state.controls.jump && !self.state.prev_controls.jump;
 

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -859,7 +859,7 @@ impl Car {
         }
 
         if self.vel_impulse_cache != Vec3A::ZERO {
-            rb.lin_vel += self.vel_impulse_cache * UU_TO_BT;
+            rb.lin_vel += self.vel_impulse_cache;
             self.vel_impulse_cache = Vec3A::ZERO;
         }
 

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -463,7 +463,7 @@ impl Car {
     ) {
         let up_dir = self.state.get_up_dir();
 
-        if self.state.is_on_ground && self.state.is_jumping {
+        if self.state.is_on_ground && !self.state.is_jumping {
             if self.state.has_jumped
                 && self.state.jump_time
                     < const { car_consts::jump::MIN_TIME + car_consts::jump::RESET_TIME_PAD }

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -313,7 +313,10 @@ impl Car {
 
             if self.state.handbrake_val != 0.0 {
                 let handbrake_amount = self.state.handbrake_val;
-                lat_friction *= 1.0 - curves::HANDBRAKE_LAT_FRICTION_FACTOR * handbrake_amount;
+                lat_friction *= 1.0
+                    + (curves::HANDBRAKE_LAT_FRICTION_FACTOR.get_output(friction_curve_input)
+                        - 1.0)
+                        * handbrake_amount;
                 long_friction *= 1.0
                     + (curves::HANDBRAKE_LONG_FRICTION_FACTOR.get_output(friction_curve_input)
                         - 1.0)

--- a/rocketsim/src/sim/consts.rs
+++ b/rocketsim/src/sim/consts.rs
@@ -393,7 +393,8 @@ pub mod curves {
     pub const LAT_FRICTION: LinearPieceCurve<2> = LinearPieceCurve::new([(0., 1.0), (1., 0.2)]);
     pub const LAT_FRICTION_THREEWHEEL: LinearPieceCurve<2> =
         LinearPieceCurve::new([(0., 0.30), (1., 0.25)]);
-    pub const HANDBRAKE_LAT_FRICTION_FACTOR: f32 = 0.9;
+    pub const HANDBRAKE_LAT_FRICTION_FACTOR: LinearPieceCurve<1> =
+        LinearPieceCurve::new([(0., 0.1)]);
     pub const HANDBRAKE_LONG_FRICTION_FACTOR: LinearPieceCurve<2> =
         LinearPieceCurve::new([(0., 0.5), (1., 0.9)]);
     pub const BALL_CAR_EXTRA_IMPULSE_FACTOR: LinearPieceCurve<4> =

--- a/rocketsim/src/sim/mutator_config.rs
+++ b/rocketsim/src/sim/mutator_config.rs
@@ -33,7 +33,6 @@ pub struct MutatorConfig {
 
     pub ball_hit_extra_force_scale: f32,
     pub bump_force_scale: f32,
-    pub bump_requires_front_hit: bool,
     pub ball_radius: f32,
     pub unlimited_flips: bool,
     pub unlimited_double_jumps: bool,
@@ -86,7 +85,6 @@ impl MutatorConfig {
             boost_pad_cooldown_small: consts::boost_pads::COOLDOWN_SMALL,
             ball_hit_extra_force_scale: 1.,
             bump_force_scale: 1.,
-            bump_requires_front_hit: false, // No longer required in newer Rocket League versions
             ball_radius: consts::ball::get_radius(game_mode),
             unlimited_flips: false,
             unlimited_double_jumps: false,

--- a/rocketsim/tests/comparison_test/all_test_cases.rs
+++ b/rocketsim/tests/comparison_test/all_test_cases.rs
@@ -1,4 +1,4 @@
-use glam::{EulerRot, IVec3, Mat3A};
+use glam::{EulerRot, IVec3, Mat3A, Vec3A};
 use rocketsim::{CarControls, GameMode, Team};
 
 use crate::comparison_test::{
@@ -83,6 +83,17 @@ fn make_ball_cases() -> Vec<TestCase> {
             (-20, 3500, 50),
             (0, 0, 0),
         ),
+        TestCase {
+            name: "ball_high_speed_wall".to_string(),
+            game_mode: GameMode::Soccar,
+            car_setups: Vec::new(),
+            ball_setup: Some(
+                BallSetup::new(Vec3A::new(2619.6133, 757.27295, 1245.125))
+                    .with_vel(Vec3A::new(3222.4766, -3332.0986, -2374.8315))
+                    .with_ang_vel(Vec3A::new(0.298_214_9, -4.800_81, -1.127_672_7)),
+            ),
+            duration_ticks: 120,
+        },
     ]
 }
 
@@ -231,6 +242,28 @@ fn make_car_cases() -> Vec<TestCase> {
             ControlSeq::new(),
             false,
         ),
+        TestCase {
+            name: "car_pogo_corner".to_string(),
+            game_mode: GameMode::Soccar,
+            car_setups: vec![
+                CarSetup::new(
+                    Team::Blue,
+                    glam::Vec3A::new(3110.3013, -4453.914, 381.41904),
+                )
+                .with_rot(Mat3A::from_euler(
+                    EulerRot::ZYX,
+                    -1.274_397_9,
+                    0.290_055_45,
+                    1.963_096_1,
+                ))
+                .with_vel(glam::Vec3A::new(-243.450_99, -592.967, -2326.8142))
+                .with_ang_vel(glam::Vec3A::new(1.894_568_4, -0.262_081_27, -0.402_835_25))
+                .with_control_seq(ControlSeq::new())
+                .with_on_ground(false),
+            ],
+            ball_setup: None,
+            duration_ticks: 120,
+        },
         simple_car_case(
             "double_jump",
             2,
@@ -354,6 +387,29 @@ fn make_car_ball_cases() -> Vec<TestCase> {
             ControlSeq::new_single(quick_air(-0.5, 0.8, 1.0, false, true)),
             true,
         ),
+        TestCase {
+            name: "car_ball_spinning_air_hit".to_string(),
+            game_mode: GameMode::Soccar,
+            car_setups: vec![
+                CarSetup::new(Team::Blue, Vec3A::new(1471.7051, -340.60132, 301.97357))
+                    .with_rot(Mat3A::from_euler(
+                        EulerRot::ZYX,
+                        -2.406_891_6,
+                        -0.059_030_056,
+                        0.494_189_74,
+                    ))
+                    .with_vel(Vec3A::new(-529.14624, -1781.6398, -1157.8341))
+                    .with_ang_vel(Vec3A::new(5.114_675_5, -4.939_43, -1.468_515_4))
+                    .with_control_seq(ControlSeq::new())
+                    .with_on_ground(false),
+            ],
+            ball_setup: Some(
+                BallSetup::new(Vec3A::new(1279.0969, -427.01538, 406.70615))
+                    .with_vel(Vec3A::new(772.5327, 947.9053, -760.2742))
+                    .with_ang_vel(Vec3A::new(4.382_030_5, 0.221_350_67, 2.986_855_5)),
+            ),
+            duration_ticks: 80,
+        },
     ]
 }
 
@@ -437,6 +493,34 @@ fn make_car_car_cases() -> Vec<TestCase> {
             (0, 0, 0),
             ControlSeq::new(),
         ),
+        TestCase {
+            name: "car_car_air_overlap".to_string(),
+            game_mode: GameMode::Soccar,
+            car_setups: vec![
+                CarSetup::new(Team::Blue, Vec3A::new(176.49292, -15.555908, 372.59656))
+                    .with_rot(Mat3A::from_euler(
+                        EulerRot::ZYX,
+                        -1.820_559_9,
+                        0.773_807_3,
+                        -1.268_840_9,
+                    ))
+                    .with_vel(Vec3A::new(-598.2096, -1011.16626, -241.30719))
+                    .with_ang_vel(Vec3A::new(-0.091_379_166, 5.100_671, 3.726_528_2))
+                    .with_control_seq(ControlSeq::new()),
+                CarSetup::new(Team::Orange, Vec3A::new(196.46584, -178.67627, 399.98947))
+                    .with_rot(Mat3A::from_euler(
+                        EulerRot::ZYX,
+                        -3.010_762_7,
+                        -1.644_297_4,
+                        1.026_696_9,
+                    ))
+                    .with_vel(Vec3A::new(-1901.5684, 724.4038, 29.772_827))
+                    .with_ang_vel(Vec3A::new(-3.380_295, -1.544_488_2, 2.699_977))
+                    .with_control_seq(ControlSeq::new()),
+            ],
+            ball_setup: None,
+            duration_ticks: 80,
+        },
     ]
 }
 

--- a/rocketsim/tests/comparison_test/state_convert.rs
+++ b/rocketsim/tests/comparison_test/state_convert.rs
@@ -177,6 +177,13 @@ pub fn conv_to_old_ball_state(ball_state: &BallState) -> OldBallState {
 }
 
 pub fn conv_to_new_ball_state(ball_state: &OldBallState) -> BallState {
+    conv_to_new_ball_state_with_last_extra_hit(ball_state, None)
+}
+
+pub fn conv_to_new_ball_state_with_last_extra_hit(
+    ball_state: &OldBallState,
+    last_extra_hit_tick: Option<u64>,
+) -> BallState {
     BallState {
         phys: PhysState {
             pos: vec3_to_new(ball_state.pos),
@@ -189,9 +196,20 @@ pub fn conv_to_new_ball_state(ball_state: &OldBallState) -> BallState {
         hs_info: Default::default(),
         ds_info: Default::default(),
 
-        // TODO: Implement
-        last_extra_hit_tick: None,
+        last_extra_hit_tick,
         tick_count_since_kickoff: 0,
+    }
+}
+
+pub const fn conv_to_new_last_extra_hit_tick(old_car_state: &OldCarState) -> Option<u64> {
+    if old_car_state.ball_hit_info.is_valid {
+        Some(
+            old_car_state
+                .ball_hit_info
+                .tick_count_when_extra_impulse_applied,
+        )
+    } else {
+        None
     }
 }
 

--- a/rocketsim/tests/comparison_test/test_case.rs
+++ b/rocketsim/tests/comparison_test/test_case.rs
@@ -170,7 +170,17 @@ impl TestCase {
             let ball_state_pair = if self.ball_setup.is_some() {
                 let new_ball_state = *new_arena.get_ball_state();
                 let old_ball_state = old_arena_ptr.pin_mut().get_ball();
-                let old_ball_state_conv = state_convert::conv_to_new_ball_state(&old_ball_state);
+                let last_extra_hit_tick = (0..self.car_setups.len())
+                    .filter_map(|i| {
+                        let old_car_idx = (i + 1) as u32;
+                        let old_car_state = old_arena_ptr.pin_mut().get_car(old_car_idx);
+                        state_convert::conv_to_new_last_extra_hit_tick(&old_car_state)
+                    })
+                    .max();
+                let old_ball_state_conv = state_convert::conv_to_new_ball_state_with_last_extra_hit(
+                    &old_ball_state,
+                    last_extra_hit_tick,
+                );
                 new_arena.set_ball_state(old_ball_state_conv);
                 Some((new_ball_state, old_ball_state_conv))
             } else {

--- a/rocketsim/tests/test_all.rs
+++ b/rocketsim/tests/test_all.rs
@@ -61,6 +61,7 @@ fn assert_test_result(test_case: &TestCase, test_result: &TestResult) {
     "ball_into_goal",
     "ball_crossbar_down",
     "ball_post_out",
+    "ball_high_speed_wall",
     "car_drive_forward",
     "car_drive_forward_boost",
     "car_drive_forward_turn",
@@ -72,14 +73,17 @@ fn assert_test_result(test_case: &TestCase, test_result: &TestResult) {
     "car_land_ground_complex",
     "car_land_ground_powerslide",
     "car_pogo",
+    "car_pogo_corner",
     "car_double_jump",
     "car_flip_simple",
     "car_flip_complex",
     "car_auto_roll",
     "car_ball_basic_air_hit",
     "car_ball_complex_air_hit",
+    "car_ball_spinning_air_hit",
     "car_car_basic_bump",
     "car_car_basic_demo",
+    "car_car_air_overlap",
 ])]
 fn run_case(case_name: &str) {
     let test_cases = init_for_test();


### PR DESCRIPTION
- Fixes car hitbox collision parity for car-car and car-ball interactions
- Corrects OBB/box contact generation, including shape selection, transforms, margins, and sphere-inside-box contacts
- Fixes bump and car-ball extra impulse behavior so contacts no longer over- or re-apply impulses
- Fixes demo-case suspension raycast parity by ignoring zero-distance compound hitbox ray hits that could mask valid ground contacts
- Matched Bullet’s `btBoxShape` margin behavior for support vertices and local inertia
- Fixed car hitbox vs arena mesh collision detection by including Bullet’s collision margin/contact threshold in compound-vs-triangle SAT checks
- Fixed rotated car hitbox OBB-vs-OBB SAT detection
- Add more tests that initially failed (only 2 currently fail)
- Full original test suite now passes