### PR TITLE
Use transposed inertia for lateral friction torque

### DIFF
--- a/rocketsim/src/bullet/dynamics/constraint_solver/seq_impulse_constraint_solver.rs
+++ b/rocketsim/src/bullet/dynamics/constraint_solver/seq_impulse_constraint_solver.rs
@@ -341,7 +341,8 @@ impl SeqImpulseConstraintSolver {
             (
                 lateral_friction_dir_1,
                 torque_axis,
-                body.inv_inertia_tensor_world * torque_axis,
+                body.inv_inertia_tensor_world
+                    .mul_transpose_vec3a(torque_axis),
             )
         };
 


### PR DESCRIPTION
This brings the calculation of the angular component for special contacts inline with the same for non-special contacts.spe