### PR TITLE
Add `Arena::is_inside`

### DIFF
--- a/rocketsim/build.rs
+++ b/rocketsim/build.rs
@@ -1,5 +1,4 @@
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
 
 fn generate_comparison_tests() {
     println!("cargo:rerun-if-changed=tests/rl_comparison_tests/test_recordings");

--- a/rocketsim/src/base.rs
+++ b/rocketsim/src/base.rs
@@ -1,13 +1,13 @@
-use log::{error, info, warn};
-use rustc_hash::FxHashMap;
-use std::sync::Mutex;
 use std::{
     fs,
     io::{Error as IoError, ErrorKind, Result as IoResult},
     path::Path,
-    sync::{Arc, OnceLock, RwLock},
+    sync::{Arc, Mutex, OnceLock, RwLock},
     time::Instant,
 };
+
+use log::{error, info, warn};
+use rustc_hash::FxHashMap;
 
 use crate::{
     bullet::collision::shapes::bvh_triangle_mesh_shape::BvhTriangleMeshShape,

--- a/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
+++ b/rocketsim/src/bullet/collision/dispatch/collision_dispatcher.rs
@@ -7,11 +7,27 @@ use crate::bullet::{
     collision::{
         broadphase::{BroadphaseProxy, GridBroadphase},
         dispatch::convex_convex_collision_alg,
-        narrowphase::persistent_manifold::{ContactAddedCallback, PersistentManifold},
+        narrowphase::{
+            manifold_point::ManifoldPoint,
+            persistent_manifold::{ContactAddedCallback, PersistentManifold},
+        },
         shapes::collision_shape::CollisionShapes,
     },
     dynamics::rigid_body::RigidBody,
 };
+
+struct NoOpCallback;
+
+impl ContactAddedCallback for NoOpCallback {
+    fn callback(
+        &mut self,
+        _contact_point: &mut ManifoldPoint,
+        _body_a: &RigidBody,
+        _body_b: &RigidBody,
+        _idx: Option<usize>,
+    ) {
+    }
+}
 
 pub struct CollisionDispatcher {
     pub manifolds: Vec<PersistentManifold>,
@@ -26,6 +42,10 @@ impl Default for CollisionDispatcher {
 }
 
 impl CollisionDispatcher {
+    pub fn test_collision(body_a: &RigidBody, body_b: &RigidBody) -> bool {
+        Self::process_collision(body_a, body_b, &mut NoOpCallback).is_some()
+    }
+
     fn process_collision<'a, T: ContactAddedCallback>(
         col_obj_a: &'a RigidBody,
         col_obj_b: &'a RigidBody,

--- a/rocketsim/src/bullet/dynamics/discrete_dynamics_world.rs
+++ b/rocketsim/src/bullet/dynamics/discrete_dynamics_world.rs
@@ -2,18 +2,25 @@ use glam::Vec3A;
 
 use super::{
     constraint_solver::seq_impulse_constraint_solver::SeqImpulseConstraintSolver,
-    rigid_body::{ActivationState, RigidBody},
+    rigid_body::{ActivationState, RigidBody, RigidBodyConstructionInfo},
 };
-use crate::bullet::{
-    collision::{
-        broadphase::{CollisionFilterGroups, GridBroadphase},
-        dispatch::{
-            collision_world::CollisionWorld,
-            ray_packet_callbacks::{QuadRayCallback, RayResultCallback},
+use crate::{
+    bullet::{
+        collision::{
+            broadphase::{CollisionFilterGroups, GridBroadphase},
+            dispatch::{
+                collision_dispatcher::CollisionDispatcher,
+                collision_world::CollisionWorld,
+                ray_packet_callbacks::{
+                    ClosestRayResultCallback, QuadRayCallback, RayResultCallback,
+                },
+            },
+            narrowphase::persistent_manifold::ContactAddedCallback,
+            shapes::{collision_shape::CollisionShapes, sphere_shape::SphereShape},
         },
-        narrowphase::persistent_manifold::ContactAddedCallback,
+        dynamics::rigid_body::CollisionFlags,
     },
-    dynamics::rigid_body::CollisionFlags,
+    shared::Aabb,
 };
 
 pub struct DiscreteDynamicsWorld {
@@ -41,6 +48,66 @@ impl DiscreteDynamicsWorld {
     #[inline]
     pub fn bodies(&self) -> &[RigidBody] {
         &self.collision_world.collision_objs
+    }
+
+    pub fn test_collision(&self, body_a: &RigidBody, body_b: &RigidBody) -> bool {
+        CollisionDispatcher::test_collision(body_a, body_b)
+    }
+
+    /// Test a packet of 4 rays against all static bodies, returning whether each ray hit anything.
+    pub fn test_ray_packet(&self, ray_from: &[Vec3A; 4], ray_to: &[Vec3A; 4]) -> [bool; 4] {
+        let mut query_body = RigidBody::new(RigidBodyConstructionInfo::new(
+            0.0,
+            CollisionShapes::Sphere(SphereShape::new(0.0)),
+        ));
+        query_body.world_array_idx = usize::MAX;
+
+        let ray_min = ray_from[0]
+            .min(ray_from[1])
+            .min(ray_from[2])
+            .min(ray_from[3])
+            .min(ray_to[0])
+            .min(ray_to[1])
+            .min(ray_to[2])
+            .min(ray_to[3]);
+        let ray_max = ray_from[0]
+            .max(ray_from[1])
+            .max(ray_from[2])
+            .max(ray_from[3])
+            .max(ray_to[0])
+            .max(ray_to[1])
+            .max(ray_to[2])
+            .max(ray_to[3]);
+        let ray_aabb = Aabb::new(ray_min, ray_max);
+
+        let mut callback = ClosestRayResultCallback::new(ray_from, ray_to, &query_body);
+
+        for body in &self.collision_world.collision_objs {
+            if !body.is_static_obj() {
+                continue;
+            }
+
+            let body_aabb = body.get_collision_shape().get_aabb(body.get_world_trans());
+
+            if !ray_aabb.intersects(&body_aabb) {
+                continue;
+            }
+
+            CollisionWorld::quad_ray_test(
+                ray_from,
+                ray_to,
+                body,
+                body.world_array_idx,
+                &mut callback,
+            );
+        }
+
+        [
+            callback.has_hit(0),
+            callback.has_hit(1),
+            callback.has_hit(2),
+            callback.has_hit(3),
+        ]
     }
 
     pub fn ray_test<T: RayResultCallback>(

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -17,7 +17,10 @@ use crate::{
         collision::{
             broadphase::{CollisionFilterGroups, GridBroadphase},
             narrowphase::manifold_point::ManifoldPoint,
-            shapes::{collision_shape::CollisionShapes, static_plane_shape::StaticPlaneShape},
+            shapes::{
+                box_shape::BoxShape, collision_shape::CollisionShapes,
+                compound_shape::CompoundShape, static_plane_shape::StaticPlaneShape,
+            },
         },
         dynamics::{
             discrete_dynamics_world::DiscreteDynamicsWorld,
@@ -324,6 +327,95 @@ impl Arena {
             GameMode::Dropshot => ball_pos.z < -self.config.mutators.ball_radius * 1.75,
             GameMode::TheVoid => false,
         }
+    }
+
+    /// Returns true if the given object is within the arena bounds and not touching any static geometry.
+    ///
+    /// If `car_config` is `None`, the object is treated as a ball using the arena's current ball
+    /// configuration (including game mode and mutators).
+    ///
+    /// NOTE: Car wheels are not included in the collision test.
+    #[must_use]
+    pub fn is_inside(&self, phys: PhysState, car_config: Option<CarBodyConfig>) -> bool {
+        let game_mode = self.config.game_mode;
+        if game_mode == GameMode::TheVoid {
+            return true;
+        }
+
+        let arena_aabb = consts::arena::get_aabb(game_mode);
+        let pos_bt = phys.pos * UU_TO_BT;
+        let world_trans = Affine3A {
+            matrix3: phys.rot_mat,
+            translation: pos_bt,
+        };
+
+        let (query_shape, query_aabb) = if let Some(config) = car_config {
+            let box_shape = BoxShape::new(config.hitbox_size * UU_TO_BT * 0.5);
+            let hitbox_offset = Affine3A {
+                matrix3: Mat3A::IDENTITY,
+                translation: config.hitbox_pos_offset * UU_TO_BT,
+            };
+            let compound_shape = CompoundShape::new(box_shape, hitbox_offset);
+            let aabb = compound_shape.get_aabb(&world_trans);
+            (CollisionShapes::Compound(compound_shape), aabb)
+        } else {
+            let (shape, _) = Ball::make_ball_collision_shape(game_mode, &self.config.mutators);
+            let aabb = shape.get_aabb(&world_trans);
+            (shape, aabb)
+        };
+
+        // Check if query AABB is fully contained within the arena AABB
+        if !arena_aabb.min.cmple(query_aabb.min).all()
+            || !arena_aabb.max.cmpge(query_aabb.max).all()
+        {
+            return false;
+        }
+
+        let mut rb_info = RigidBodyConstructionInfo::new(0.0, query_shape);
+        rb_info.start_world_trans = world_trans;
+        let mut query_body = RigidBody::new(rb_info);
+        query_body.world_array_idx = usize::MAX;
+
+        for body in self.bullet_world.bodies() {
+            if !body.is_static_obj() {
+                continue;
+            }
+
+            let body_aabb = body.get_collision_shape().get_aabb(body.get_world_trans());
+            if !query_aabb.intersects(&body_aabb) {
+                continue;
+            }
+
+            if self.bullet_world.test_collision(&query_body, body) {
+                return false;
+            }
+        }
+
+        // 6-directional ray cast to verify the point is fully enclosed by static geometry
+        const RAY_LENGTH: f32 = 100_000.0 * UU_TO_BT;
+        let ray_from = [pos_bt; 4];
+
+        let ray_to_1 = [
+            pos_bt + Vec3A::X * RAY_LENGTH,
+            pos_bt + Vec3A::NEG_X * RAY_LENGTH,
+            pos_bt + Vec3A::Y * RAY_LENGTH,
+            pos_bt + Vec3A::NEG_Y * RAY_LENGTH,
+        ];
+        let hits_1 = self.bullet_world.test_ray_packet(&ray_from, &ray_to_1);
+
+        let ray_to_2 = [
+            pos_bt + Vec3A::Z * RAY_LENGTH,
+            pos_bt + Vec3A::NEG_Z * RAY_LENGTH,
+            pos_bt + Vec3A::Z * RAY_LENGTH,
+            pos_bt + Vec3A::NEG_Z * RAY_LENGTH,
+        ];
+        let hits_2 = self.bullet_world.test_ray_packet(&ray_from, &ray_to_2);
+
+        if !hits_1[0] || !hits_1[1] || !hits_1[2] || !hits_1[3] || !hits_2[0] || !hits_2[1] {
+            return false;
+        }
+
+        true
     }
 
     pub fn reset_to_random_kickoff(&mut self, rng_seed: Option<u64>) {

--- a/rocketsim/src/sim/ball/base.rs
+++ b/rocketsim/src/sim/ball/base.rs
@@ -31,7 +31,7 @@ pub(crate) struct Ball {
 }
 
 impl Ball {
-    fn make_ball_collision_shape(
+    pub(crate) fn make_ball_collision_shape(
         game_mode: GameMode,
         mutator_config: &MutatorConfig,
     ) -> (CollisionShapes, Vec3A) {

--- a/rocketsim/tests/arena_test.rs
+++ b/rocketsim/tests/arena_test.rs
@@ -1,0 +1,328 @@
+use std::sync::Once;
+
+use glam::Vec3A;
+use rocketsim::{Arena, CarBodyConfig, GameMode, Team};
+
+static INIT: Once = Once::new();
+
+fn init() {
+    INIT.call_once(|| {
+        rocketsim::init_from_default(true).unwrap();
+    });
+}
+
+#[test]
+fn test_ball_the_void_always_inside() {
+    init();
+    let arena = Arena::new(GameMode::TheVoid);
+    let ball_state = arena.get_ball_state();
+
+    // Ball at rest should be inside TheVoid
+    assert!(arena.is_inside(ball_state.phys, None));
+
+    // Ball way outside should also be inside TheVoid
+    let mut phys = ball_state.phys;
+    phys.pos = Vec3A::new(100000.0, 100000.0, 100000.0);
+    assert!(arena.is_inside(phys, None));
+}
+
+#[test]
+fn test_ball_on_floor_not_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    let ball_state = arena.get_ball_state();
+
+    // Ball at rest on floor is touching the floor static plane
+    assert!(!arena.is_inside(ball_state.phys, None));
+}
+
+#[test]
+fn test_ball_in_air_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    let mut phys = arena.get_ball_state().phys;
+
+    // Center of arena, well above the floor
+    phys.pos = Vec3A::new(0.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, None));
+
+    // Near the wall but not touching
+    phys.pos = Vec3A::new(3500.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, None));
+
+    // Near the ceiling but not touching
+    phys.pos = Vec3A::new(0.0, 0.0, 1900.0);
+    assert!(arena.is_inside(phys, None));
+}
+
+#[test]
+fn test_ball_outside_arena() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    let mut phys = arena.get_ball_state().phys;
+
+    // Beyond the wall
+    phys.pos = Vec3A::new(5000.0, 0.0, 1000.0);
+    assert!(!arena.is_inside(phys, None));
+
+    // Beyond the ceiling
+    phys.pos = Vec3A::new(0.0, 0.0, 2500.0);
+    assert!(!arena.is_inside(phys, None));
+
+    // Below the floor
+    phys.pos = Vec3A::new(0.0, 0.0, -100.0);
+    assert!(!arena.is_inside(phys, None));
+}
+
+#[test]
+fn test_ball_touching_wall_not_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    let mut phys = arena.get_ball_state().phys;
+
+    // Ball touching the side wall (arena max_x is 4096, ball radius is ~92.75)
+    // Ball center should be at 4096 - ball_radius to be exactly touching
+    let ball_radius = arena.get_config().mutators.ball_radius;
+    phys.pos = Vec3A::new(4096.0 - ball_radius, 0.0, 1000.0);
+    assert!(!arena.is_inside(phys, None));
+
+    // Ball touching the ceiling
+    phys.pos = Vec3A::new(0.0, 0.0, 2048.0 - ball_radius);
+    assert!(!arena.is_inside(phys, None));
+}
+
+#[test]
+fn test_car_in_air_inside() {
+    init();
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::OCTANE);
+    let car_state = *arena.get_car_state(car_idx);
+    let mut phys = car_state.phys;
+
+    // Car in the air at center of arena
+    phys.pos = Vec3A::new(0.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+
+    // Car near the wall but not touching
+    phys.pos = Vec3A::new(3000.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+}
+
+#[test]
+fn test_car_on_floor_inside() {
+    init();
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::OCTANE);
+    let car_state = *arena.get_car_state(car_idx);
+
+    // Car at rest on floor - hitbox is above the floor, wheels touch floor but are not tested
+    assert!(arena.is_inside(car_state.phys, Some(CarBodyConfig::OCTANE)));
+}
+
+#[test]
+fn test_car_touching_wall_not_inside() {
+    init();
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::OCTANE);
+    let car_state = *arena.get_car_state(car_idx);
+    let mut phys = car_state.phys;
+
+    // Position car well past the wall at x=4096
+    // The car hitbox front extends ~73.86 UU from COM, so x=4090 is well past the wall
+    phys.pos = Vec3A::new(4090.0, 0.0, 1000.0);
+    assert!(!arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+}
+
+#[test]
+fn test_car_outside_arena() {
+    init();
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::OCTANE);
+    let car_state = *arena.get_car_state(car_idx);
+    let mut phys = car_state.phys;
+
+    // Car beyond the wall
+    phys.pos = Vec3A::new(5000.0, 0.0, 1000.0);
+    assert!(!arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+
+    // Car above the ceiling
+    phys.pos = Vec3A::new(0.0, 0.0, 2500.0);
+    assert!(!arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+}
+
+#[test]
+fn test_car_different_hitboxes() {
+    init();
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::DOMINUS);
+    let car_state = *arena.get_car_state(car_idx);
+    let mut phys = car_state.phys;
+
+    // Car in the air
+    phys.pos = Vec3A::new(0.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::DOMINUS)));
+
+    // Car on floor - hitbox is above the floor
+    phys.pos = car_state.phys.pos;
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::DOMINUS)));
+}
+
+#[test]
+fn test_ball_hoops_mode() {
+    init();
+    let arena = Arena::new(GameMode::Hoops);
+    let mut phys = arena.get_ball_state().phys;
+
+    // Ball in the air in hoops arena
+    phys.pos = Vec3A::new(0.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, None));
+
+    // Ball touching the floor
+    let ball_radius = arena.get_config().mutators.ball_radius;
+    phys.pos = Vec3A::new(0.0, 0.0, ball_radius);
+    assert!(!arena.is_inside(phys, None));
+}
+
+#[test]
+fn test_car_hoops_mode() {
+    init();
+    let mut arena = Arena::new(GameMode::Hoops);
+    let car_idx = arena.add_car(Team::Blue, CarBodyConfig::OCTANE);
+    let car_state = *arena.get_car_state(car_idx);
+    let mut phys = car_state.phys;
+
+    // Car in the air
+    phys.pos = Vec3A::new(0.0, 0.0, 1000.0);
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+
+    // Car on floor - hitbox is above the floor
+    phys.pos = car_state.phys.pos;
+    assert!(arena.is_inside(phys, Some(CarBodyConfig::OCTANE)));
+}
+
+// Arena corner geometry:
+// - Side wall: x = ±4096
+// - Back wall: y = ±5120
+// - Corner wall at 45°: x + y = 8064 (positive quadrant), x + y = -8064 (negative), etc.
+// - Corner wall length: 1629.174
+
+fn ball_phys_at(pos: Vec3A) -> rocketsim::PhysState {
+    rocketsim::PhysState {
+        pos,
+        rot_mat: glam::Mat3A::IDENTITY,
+        vel: Vec3A::ZERO,
+        ang_vel: Vec3A::ZERO,
+    }
+}
+
+#[test]
+fn test_ball_corner_pos_pos_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Well inside the (+x, +y) corner wall (x + y = 8064)
+    assert!(arena.is_inside(ball_phys_at(Vec3A::new(3800.0, 3800.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_pos_pos_touching() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Ball touching the (+x, +y) corner wall.
+    // Ball radius ≈ 91.25. Distance to wall = 91.25 ⇒ x + y = 8064 − 91.25·√2 ≈ 7935.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(3967.5, 3967.5, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_pos_pos_outside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Past the corner wall but within side/back wall bounds.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(4000.0, 4000.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_pos_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Well inside the (−x, +y) corner wall (y − x = 8064)
+    assert!(arena.is_inside(ball_phys_at(Vec3A::new(-3800.0, 3800.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_pos_touching() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Ball touching the (−x, +y) corner wall: y − x = 7935.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(-3967.5, 3967.5, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_pos_outside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(-4000.0, 4000.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_pos_neg_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Well inside the (+x, −y) corner wall (x − y = 8064)
+    assert!(arena.is_inside(ball_phys_at(Vec3A::new(3800.0, -3800.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_pos_neg_touching() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Ball touching the (+x, −y) corner wall: x − y = 7935.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(3967.5, -3967.5, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_pos_neg_outside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(4000.0, -4000.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_neg_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Well inside the (−x, −y) corner wall (x + y = −8064)
+    assert!(arena.is_inside(ball_phys_at(Vec3A::new(-3800.0, -3800.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_neg_touching() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Ball touching the (−x, −y) corner wall: x + y = −7935.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(-3967.5, -3967.5, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_neg_neg_outside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(-4000.0, -4000.0, 500.0)), None));
+}
+
+#[test]
+fn test_ball_corner_low_z_inside() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Ball near the corner but above the wall bottom ramp (ramp radius ≈ 256 uu)
+    assert!(arena.is_inside(ball_phys_at(Vec3A::new(3800.0, 3800.0, 300.0)), None));
+}
+
+#[test]
+fn test_ball_behind_back_wall_not_in_net() {
+    init();
+    let arena = Arena::new(GameMode::Soccar);
+    // Behind the back wall (y = 5120) but not in the goal net.
+    // The goal is centered at x=0 with width ~1785.5 (center-to-post 892.755).
+    // x=2000 is outside the goal opening, so the back wall mesh blocks it.
+    assert!(!arena.is_inside(ball_phys_at(Vec3A::new(2000.0, 5500.0, 500.0)), None));
+}

--- a/rocketsim/tests/mod.rs
+++ b/rocketsim/tests/mod.rs
@@ -1,1 +1,2 @@
+mod arena_test;
 mod rl_comparison_test;

--- a/rocketsim/tests/rl_comparison_test/compare.rs
+++ b/rocketsim/tests/rl_comparison_test/compare.rs
@@ -1,9 +1,9 @@
-use crate::rl_comparison_test::recording::cpp_records::{CarRecord, PhysRecord, TickRecord};
+use std::{collections::HashMap, fmt::Debug};
+
 use glam::Vec3A;
-use rocketsim::consts::TICK_TIME;
-use rocketsim::{BallState, CarState, PhysState};
-use std::collections::HashMap;
-use std::fmt::Debug;
+use rocketsim::{BallState, CarState, PhysState, consts::TICK_TIME};
+
+use crate::rl_comparison_test::recording::cpp_records::{CarRecord, PhysRecord, TickRecord};
 
 #[derive(Copy, Clone, Debug)]
 #[allow(dead_code)]

--- a/rocketsim/tests/rl_comparison_test/mod.rs
+++ b/rocketsim/tests/rl_comparison_test/mod.rs
@@ -1,6 +1,6 @@
-use crate::rl_comparison_test::recording::Recording;
-use crate::rl_comparison_test::recording::cpp_records::TickRecord;
 use rocketsim::{Arena, CarBodyConfig, CarControls, CarState, GameMode, PhysState, Team};
+
+use crate::rl_comparison_test::recording::{Recording, cpp_records::TickRecord};
 
 mod compare;
 mod recording;
@@ -12,7 +12,7 @@ pub fn set_state_to_record_tick(
     car_controls: &CarControls,
 ) {
     let mut cs = *arena.get_car_state(car_idx);
-    let rep_cs: CarState = tick.car_record.clone().into();
+    let rep_cs: CarState = tick.car_record.into();
     cs.phys = rep_cs.phys;
     cs.is_jumping = rep_cs.is_jumping;
     cs.is_flipping = rep_cs.is_flipping;
@@ -22,7 +22,7 @@ pub fn set_state_to_record_tick(
 
     arena.set_car_state(car_idx, cs);
 
-    let rep_bs_phys: PhysState = tick.ball_record.clone().into();
+    let rep_bs_phys: PhysState = tick.ball_record.into();
     let mut bs = *arena.get_ball_state();
     bs.phys = rep_bs_phys;
     arena.set_ball_state(bs);

--- a/rocketsim/tests/rl_comparison_test/recording/cpp_records.rs
+++ b/rocketsim/tests/rl_comparison_test/recording/cpp_records.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use std::ops::{Index, IndexMut};
+
 use glam::{Mat3A, Vec3A};
 use rocketsim::{CarControls, CarState, PhysState};
-use std::ops::{Index, IndexMut};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VecRecord {

--- a/rocketsim/tests/rl_comparison_test/recording/data_reader.rs
+++ b/rocketsim/tests/rl_comparison_test/recording/data_reader.rs
@@ -1,5 +1,6 @@
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::{self, ErrorKind, Read}; // Or BigEndian, matching your C++ export
+use std::io::{self, ErrorKind, Read};
+
+use byteorder::{LittleEndian, ReadBytesExt}; // Or BigEndian, matching your C++ export
 
 pub struct DataReader<R: Read> {
     stream: R,

--- a/rocketsim/tests/rl_comparison_test/recording/mod.rs
+++ b/rocketsim/tests/rl_comparison_test/recording/mod.rs
@@ -1,9 +1,10 @@
 pub mod cpp_records;
 mod data_reader;
 
+use std::io::{BufReader, ErrorKind};
+
 use cpp_records::*;
 use data_reader::DataReader;
-use std::io::{BufReader, ErrorKind};
 
 const RLPR_MAGIC_BYTES: [u8; 4] = [82, 76, 80, 82];
 const RLPR_VERSION: u32 = 0;


### PR DESCRIPTION
This implementation prioritizes correctness over speed, since it shouldn't be ran with regularity. Only occasionally in state setters.

- Add CollisionDispatcher::test_collision for boolean collision queries.
- Make Ball::make_ball_collision_shape visible within crate.
- Include comprehensive arena collision tests.