### PR TITLE
Default to 0 instead of panicking in num_boost_pads

### DIFF
--- a/rocketsim/src/sim/arena/arena_state.rs
+++ b/rocketsim/src/sim/arena/arena_state.rs
@@ -1,4 +1,4 @@
-use crate::{BallState, BoostPadConfig, BoostPadState, CarInfo, CarState, GameMode};
+use crate::{BallState, BoostPadConfig, BoostPadState, CarInfo, CarState, GameMode, TileStates};
 
 #[derive(Debug, Clone)]
 pub struct ArenaState {
@@ -7,6 +7,7 @@ pub struct ArenaState {
     pub cars: Vec<(CarInfo, CarState)>,
     pub ball: BallState,
     pub boost_pads: Vec<(BoostPadConfig, BoostPadState)>,
+    pub tile_states: Option<TileStates>,
 }
 
 impl ArenaState {
@@ -23,6 +24,7 @@ impl ArenaState {
             cars: Vec::new(),
             ball: BallState::default(),
             boost_pads: Vec::new(),
+            tile_states: None,
         }
     }
 

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -692,7 +692,9 @@ impl Arena {
 
     #[must_use]
     pub fn num_boost_pads(&self) -> usize {
-        self.boost_pads().len()
+        self.boost_pad_grid
+            .as_ref()
+            .map_or(0, |grid| grid.all_pads.len())
     }
 
     #[must_use]
@@ -731,6 +733,12 @@ impl Arena {
     pub fn set_tile_states(&mut self, tile_states: TileStates) {
         self.tile_states = Some(tile_states);
         self.update_tile_states();
+    }
+
+    pub fn num_tiles(&self) -> usize {
+        self.tile_states
+            .as_ref()
+            .map_or(0, |ts| ts.states[0].len() * ts.states.len())
     }
 
     #[must_use]

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -773,6 +773,7 @@ impl Arena {
             cars,
             ball,
             boost_pads,
+            tile_states: self.tile_states,
         }
     }
 

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -5,25 +5,38 @@ use fastrand::Rng;
 use glam::{Affine3A, EulerRot, Mat3A, Vec3A};
 
 use super::ArenaContactTracker;
-use crate::bullet::collision::dispatch::quad_ray_callbacks::{ClosestQuadRayResultCallback, QuadRayResultCallback};
+use crate::bullet::collision::dispatch::quad_ray_callbacks::{
+    ClosestQuadRayResultCallback, QuadRayResultCallback,
+};
 #[cfg(feature = "vis")]
 use crate::vis::VisInst;
-use crate::{ARENA_COLLISION_SHAPES, ArenaConfig, ArenaEvent::{BallHitWorld, CarPickupBoost}, ArenaMemWeightMode, ArenaState, BallHitWorldEvent, BoostPadConfig, BoostPadGrid, BoostPadState, Car, CarBodyConfig, CarControls, CarInfo, CarPickupBoostEvent, CarState, GameMode, MutatorConfig, PhysState, RaycastQuery, RaycastResult, Team, TileDamageState, TileStates, bullet::{
-    collision::{
-        broadphase::{CollisionFilterGroups, GridBroadphase},
-        narrowphase::manifold_point::ManifoldPoint,
-        shapes::{collision_shape::CollisionShapes, static_plane_shape::StaticPlaneShape},
+use crate::{
+    ARENA_COLLISION_SHAPES, ArenaConfig,
+    ArenaEvent::{BallHitWorld, CarPickupBoost},
+    ArenaMemWeightMode, ArenaState, BallHitWorldEvent, BoostPadConfig, BoostPadGrid, BoostPadState,
+    Car, CarBodyConfig, CarControls, CarInfo, CarPickupBoostEvent, CarState, GameMode,
+    MutatorConfig, PhysState, RaycastHitInfo, RaycastQuery, RaycastResult, Team, TileDamageState,
+    TileStates,
+    bullet::{
+        collision::{
+            broadphase::{CollisionFilterGroups, GridBroadphase},
+            narrowphase::manifold_point::ManifoldPoint,
+            shapes::{collision_shape::CollisionShapes, static_plane_shape::StaticPlaneShape},
+        },
+        dynamics::{
+            discrete_dynamics_world::DiscreteDynamicsWorld,
+            rigid_body::{ActivationState, CollisionFlags, RigidBody, RigidBodyConstructionInfo},
+        },
     },
-    dynamics::{
-        discrete_dynamics_world::DiscreteDynamicsWorld,
-        rigid_body::{ActivationState, CollisionFlags, RigidBody, RigidBodyConstructionInfo},
+    consts::{self, BT_TO_UU, TICK_RATE, TICK_TIME, UU_TO_BT},
+    make_tile_shapes,
+    sim::{
+        ArenaEvent::{self, CarHitBall},
+        Ball, BallState, BoostPad, CarHitBallEvent, CarHitCarEvent, CarHitWorldEvent, DemoMode,
+        UserInfoTypes,
+        arena::ArenaEventList,
     },
-}, consts::{self, BT_TO_UU, TICK_RATE, TICK_TIME, UU_TO_BT}, make_tile_shapes, sim::{
-    ArenaEvent::{self, CarHitBall},
-    Ball, BallState, BoostPad, CarHitBallEvent, CarHitCarEvent, CarHitWorldEvent, DemoMode,
-    UserInfoTypes,
-    arena::ArenaEventList,
-}, RaycastHitInfo};
+};
 
 pub struct Arena {
     pub(crate) bullet_world: DiscreteDynamicsWorld,
@@ -750,12 +763,9 @@ impl Arena {
             .collect::<Vec<_>>();
         let ball = *self.get_ball_state();
 
-        let boost_pads = match self.config.game_mode {
-            GameMode::Soccar | GameMode::Hoops | GameMode::Snowday => (0..self.num_boost_pads())
-                .map(|i| (*self.get_boost_pad_config(i), self.get_boost_pad_state(i)))
-                .collect(),
-            GameMode::Dropshot | GameMode::Heatseeker | GameMode::TheVoid => Vec::new(),
-        };
+        let boost_pads = (0..self.num_boost_pads())
+            .map(|i| (*self.get_boost_pad_config(i), self.get_boost_pad_state(i)))
+            .collect();
 
         ArenaState {
             game_mode: self.config.game_mode,


### PR DESCRIPTION
- The current version panics instead of returning 0
- Also add a num_tiles method that returns 0 when tile_states is None.
- Add `pub tile_states: Option<TileStates>` to `ArenaState`