### PR TITLE
Refactor supersonic maintain logic to use grace timer

### DIFF
--- a/rocketsim/src/sim/ball/base.rs
+++ b/rocketsim/src/sim/ball/base.rs
@@ -266,7 +266,7 @@ impl Ball {
         let can_accel = self
             .state
             .last_extra_hit_tick
-            .is_none_or(|last_hit_tick| last_hit_tick < tick_count - 1);
+            .is_none_or(|last_hit_tick| last_hit_tick + 1 < tick_count);
 
         if rel_speed > 0.0 && can_accel {
             let extra_z_scale = game_mode == GameMode::Hoops

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -840,6 +840,11 @@ impl Car {
     }
 
     pub(crate) fn post_tick_update(&mut self, collision_world: &mut DiscreteDynamicsWorld) {
+        const START_SPEED_SQ: f32 =
+            car_consts::supersonic::START_SPEED * car_consts::supersonic::START_SPEED;
+        const MAINTAIN_MIN_SPEED_SQ: f32 =
+            car_consts::supersonic::MAINTAIN_MIN_SPEED * car_consts::supersonic::MAINTAIN_MIN_SPEED;
+
         let rb = &collision_world.bodies()[self.rigid_body_idx];
         if self.state.is_demoed {
             return;
@@ -848,22 +853,27 @@ impl Car {
         self.state.phys.rot_mat = rb.get_world_trans().matrix3;
 
         let speed_squared = (rb.lin_vel * BT_TO_UU).length_squared();
-        self.state.is_supersonic = speed_squared
-            >= if self.state.is_supersonic
-                && self.state.supersonic_time < car_consts::supersonic::MAINTAIN_MAX_TIME
-            {
-                const {
-                    car_consts::supersonic::MAINTAIN_MIN_SPEED
-                        * car_consts::supersonic::MAINTAIN_MIN_SPEED
-                }
-            } else {
-                const { car_consts::supersonic::START_SPEED * car_consts::supersonic::START_SPEED }
-            };
-
         if self.state.is_supersonic {
-            self.state.supersonic_time += TICK_TIME;
+            if speed_squared >= START_SPEED_SQ {
+                // Back above start speed: reset the maintain timer.
+                self.state.supersonic_grace_timer = 0.0;
+            } else if speed_squared < MAINTAIN_MIN_SPEED_SQ {
+                // Dropped below the minimum maintain speed: lose supersonic immediately.
+                self.state.is_supersonic = false;
+                self.state.supersonic_grace_timer = 0.0;
+            } else {
+                // Between maintain min and start speed: keep supersonic for the grace period.
+                self.state.supersonic_grace_timer += TICK_TIME;
+                if self.state.supersonic_grace_timer >= car_consts::supersonic::MAINTAIN_MAX_TIME {
+                    self.state.is_supersonic = false;
+                    self.state.supersonic_grace_timer = 0.0;
+                }
+            }
+        } else if speed_squared >= START_SPEED_SQ {
+            self.state.is_supersonic = true;
+            self.state.supersonic_grace_timer = 0.0;
         } else {
-            self.state.supersonic_time = 0.0;
+            self.state.supersonic_grace_timer = 0.0;
         }
 
         self.bullet_vehicle

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -665,8 +665,8 @@ impl Car {
                         );
                     }
                 } else {
-                    let jump_start_force = self.state.get_up_dir()
-                        * const { car_consts::jump::IMMEDIATE_FORCE * UU_TO_BT * TICK_TIME };
+                    let jump_start_force =
+                        self.state.get_up_dir() * mutator_config.jump_immediate_force * UU_TO_BT;
                     rb.add_impulse(
                         Some("double_jump"),
                         Impulse::Linear(jump_start_force),

--- a/rocketsim/src/sim/car/car_state.rs
+++ b/rocketsim/src/sim/car/car_state.rs
@@ -53,8 +53,9 @@ pub struct CarState {
     pub is_boosting: bool,
     pub boosting_time: f32,
     pub is_supersonic: bool,
-    /// Time spent supersonic, for checking with the supersonic maintain time
-    pub supersonic_time: f32,
+    /// Time since the car's speed dropped below `START_SPEED` while still supersonic,
+    /// used for the supersonic maintain grace period
+    pub supersonic_grace_timer: f32,
     /// This is a state variable due to the rise/fall rate of handbrake inputs
     pub handbrake_val: f32,
     pub is_auto_flipping: bool,
@@ -101,7 +102,7 @@ impl CarState {
         is_boosting: false,
         boosting_time: 0.0,
         is_supersonic: false,
-        supersonic_time: 0.0,
+        supersonic_grace_timer: 0.0,
         handbrake_val: 0.0,
         is_auto_flipping: false,
         world_contact_normal: None,


### PR DESCRIPTION
Logic for the `is_supersonic` grace period was previously incorrect