### PR TITLE
fix: align Rust V3 simulation with RocketSim v2

### DIFF
--- a/rocketsim/examples/best_random_benchmark.rs
+++ b/rocketsim/examples/best_random_benchmark.rs
@@ -1,0 +1,601 @@
+use std::{collections::HashSet, env, fs, mem::size_of};
+
+use glam::{Mat3A, Vec3A};
+use rocketsim::consts::{TICK_RATE, TICK_TIME};
+use rocketsim::{Arena, ArenaConfig, CarBodyConfig, CarControls, GameMode, PhysState, Team};
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VecRecord {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Mat3Record {
+    rows: [VecRecord; 3],
+}
+impl Mat3Record {
+    fn column(&self, idx: usize) -> VecRecord {
+        VecRecord {
+            x: self.rows[0].x * (idx == 0) as u8 as f32
+                + self.rows[0].y * (idx == 1) as u8 as f32
+                + self.rows[0].z * (idx == 2) as u8 as f32,
+            y: self.rows[1].x * (idx == 0) as u8 as f32
+                + self.rows[1].y * (idx == 1) as u8 as f32
+                + self.rows[1].z * (idx == 2) as u8 as f32,
+            z: self.rows[2].x * (idx == 0) as u8 as f32
+                + self.rows[2].y * (idx == 1) as u8 as f32
+                + self.rows[2].z * (idx == 2) as u8 as f32,
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct WheelRecord {
+    susp_length: f32,
+    susp_rel_vel: f32,
+    has_contact: bool,
+    contact_normal: VecRecord,
+    steer_amount: f32,
+    engine_force: f32,
+    brake: f32,
+    lat_friction: f32,
+    long_friction: f32,
+    extra_pushback: f32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ControlsRecord {
+    throttle: f32,
+    steer: f32,
+    pitch: f32,
+    yaw: f32,
+    roll: f32,
+    jump: bool,
+    boost: bool,
+    handbrake: bool,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ImpulseRecord {
+    lin: VecRecord,
+    ang: VecRecord,
+    impulse_type: u8,
+    is_accum: bool,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct PhysRecord {
+    physics_frame: u32,
+    pos: VecRecord,
+    rot: Mat3Record,
+    lin_vel: VecRecord,
+    ang_vel: VecRecord,
+    has_world_contact: bool,
+    world_contact_point: VecRecord,
+    world_contact_normal: VecRecord,
+    impulse_records_data: [ImpulseRecord; 8],
+    num_impulse_records: u32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct CarRecord {
+    phys: PhysRecord,
+    is_on_ground: bool,
+    is_jumping: bool,
+    is_flipping: bool,
+    jump_time: f32,
+    flip_time: f32,
+    has_jumped: bool,
+    double_jumped_or_flipped: bool,
+    has_flip: bool,
+    flip_rel_torque: VecRecord,
+    boost_amount: f32,
+    is_touching_ball: bool,
+    prev_controls: ControlsRecord,
+    wheels: [WheelRecord; 4],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct RecInfo {
+    num_cars: u32,
+    hitbox_rel_min_bt: VecRecord,
+    hitbox_rel_max_bt: VecRecord,
+}
+#[derive(Clone)]
+struct Tick {
+    cars: Vec<CarRecord>,
+    ball: PhysRecord,
+}
+struct Recording {
+    ticks: Vec<Tick>,
+    num_cars: usize,
+}
+
+struct Reader {
+    bytes: Vec<u8>,
+    off: usize,
+}
+impl Reader {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes, off: 0 }
+    }
+    fn bytes(&mut self, n: usize) -> &[u8] {
+        let s = self.off;
+        self.off += n;
+        &self.bytes[s..s + n]
+    }
+    fn u8(&mut self) -> u8 {
+        self.bytes(1)[0]
+    }
+    fn u32(&mut self) -> u32 {
+        u32::from_le_bytes(self.bytes(4).try_into().unwrap())
+    }
+    fn read<T: Copy>(&mut self) -> T {
+        assert!(self.off + size_of::<T>() <= self.bytes.len());
+        let value =
+            unsafe { std::ptr::read_unaligned(self.bytes.as_ptr().add(self.off) as *const T) };
+        self.off += size_of::<T>();
+        value
+    }
+}
+
+fn parse(path: &str) -> Recording {
+    assert_eq!(size_of::<PhysRecord>(), 332);
+    assert_eq!(size_of::<CarRecord>(), 584);
+    assert_eq!(size_of::<ControlsRecord>(), 24);
+    let mut r = Reader::new(fs::read(path).expect("read RLPR"));
+    assert_eq!(r.bytes(4), b"RLPR");
+    assert_eq!(r.u8(), 0);
+    assert_eq!(r.u32(), 2);
+    assert_eq!(r.u32(), size_of::<RecInfo>() as u32);
+    let info: RecInfo = r.read();
+    assert!(info.num_cars > 0 && info.num_cars <= 2);
+    let n = r.u32() as usize;
+    let mut ticks = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mut cars = Vec::with_capacity(info.num_cars as usize);
+        for _ in 0..info.num_cars {
+            assert_eq!(r.u32(), size_of::<CarRecord>() as u32);
+            cars.push(r.read());
+        }
+        assert_eq!(r.u32(), size_of::<PhysRecord>() as u32);
+        let ball = r.read();
+        ticks.push(Tick { cars, ball });
+    }
+    assert_eq!(r.off, r.bytes.len());
+    Recording {
+        ticks,
+        num_cars: info.num_cars as usize,
+    }
+}
+
+fn v(v: VecRecord) -> Vec3A {
+    Vec3A::new(v.x, v.y, v.z)
+}
+fn phys(p: PhysRecord) -> PhysState {
+    PhysState {
+        pos: v(p.pos),
+        vel: v(p.lin_vel),
+        ang_vel: v(p.ang_vel),
+        rot_mat: Mat3A::from_cols(
+            v(VecRecord {
+                x: p.rot.rows[0].x,
+                y: p.rot.rows[1].x,
+                z: p.rot.rows[2].x,
+            }),
+            v(VecRecord {
+                x: p.rot.rows[0].y,
+                y: p.rot.rows[1].y,
+                z: p.rot.rows[2].y,
+            }),
+            v(VecRecord {
+                x: p.rot.rows[0].z,
+                y: p.rot.rows[1].z,
+                z: p.rot.rows[2].z,
+            }),
+        ),
+    }
+}
+fn controls(c: ControlsRecord) -> CarControls {
+    CarControls {
+        throttle: c.throttle,
+        steer: c.steer,
+        pitch: c.pitch,
+        yaw: c.yaw,
+        roll: c.roll,
+        jump: c.jump,
+        boost: c.boost,
+        handbrake: c.handbrake,
+    }
+}
+
+fn set_car(arena: &mut Arena, idx: usize, rec: &CarRecord, c: ControlsRecord) {
+    let mut s = *arena.get_car_state(idx);
+    let p = phys(rec.phys);
+    s.phys = p;
+    s.is_on_ground = rec.is_on_ground;
+    s.is_jumping = rec.is_jumping;
+    s.is_flipping = rec.is_flipping;
+    s.jump_ticks = (rec.jump_time * TICK_RATE).round() as u32;
+    s.flip_time = rec.flip_time;
+    s.has_jumped = rec.has_jumped;
+    if s.has_flip_or_jump() {
+        s.has_double_jumped = rec.double_jumped_or_flipped;
+    }
+    s.flip_rel_torque = v(rec.flip_rel_torque);
+    s.boost = rec.boost_amount;
+    s.controls = controls(c);
+    arena.set_car_state(idx, s);
+}
+fn set_ball(arena: &mut Arena, rec: &PhysRecord) {
+    let mut s = *arena.get_ball_state();
+    s.phys = phys(*rec);
+    arena.set_ball_state(s);
+}
+
+fn add_arena(num_cars: usize) -> (Arena, Vec<usize>) {
+    // V2's default ArenaConfig disables ball rotation tracking. Match that
+    // configuration so RLPR comparisons do not treat the visual-only sphere
+    // orientation as a physics difference.
+    let mut a = Arena::new_with_config(ArenaConfig::new(GameMode::Soccar).with_no_ball_rot(true));
+    let mut ids = Vec::with_capacity(num_cars);
+    for i in 0..num_cars {
+        ids.push(a.add_car(
+            if i % 2 == 0 { Team::Blue } else { Team::Orange },
+            CarBodyConfig::OCTANE,
+        ));
+    }
+    (a, ids)
+}
+
+fn add_vec(s: &mut f64, p: Vec3A, r: VecRecord, t: f32) {
+    *s += f64::from((p - v(r)).length() / t).powi(2);
+}
+fn add_bool(s: &mut f64, p: bool, r: bool) {
+    *s += if p == r { 0.0 } else { 1.0 };
+}
+fn add_float(s: &mut f64, p: f32, r: f32, t: f32) {
+    *s += f64::from(((p - r).abs() / t).powi(2));
+}
+fn compare_phys(sum: &mut f64, p: &PhysState, r: &PhysRecord) {
+    add_vec(sum, p.pos, r.pos, 10.0);
+    add_vec(sum, p.vel, r.lin_vel, 3.0);
+    add_vec(sum, p.ang_vel, r.ang_vel, 1.0);
+    add_vec(sum, p.get_forward_dir(), r.rot.column(0), 1.0);
+    add_vec(sum, p.get_up_dir(), r.rot.column(2), 1.0);
+}
+fn compare_tick(arena: &Arena, ids: &[usize], tick: &Tick) -> f32 {
+    let mut sum = 0.0;
+    for (i, &id) in ids.iter().enumerate() {
+        let s = arena.get_car_state(id);
+        let r = &tick.cars[i];
+        compare_phys(&mut sum, &s.phys, &r.phys);
+        add_bool(&mut sum, s.is_on_ground, r.is_on_ground);
+        add_bool(&mut sum, s.is_jumping, r.is_jumping);
+        add_bool(&mut sum, s.has_jumped, r.has_jumped);
+        if s.has_jumped {
+            add_float(&mut sum, s.jump_time(), r.jump_time, TICK_TIME * 2.0);
+        }
+        add_bool(&mut sum, s.is_flipping, r.is_flipping);
+        if s.is_flipping {
+            add_float(&mut sum, s.flip_time, r.flip_time, TICK_TIME * 2.0);
+            add_vec(&mut sum, s.flip_rel_torque, r.flip_rel_torque, 0.05);
+        }
+    }
+    compare_phys(&mut sum, &arena.get_ball_state().phys, &tick.ball);
+    sum.sqrt() as f32
+}
+
+struct Outcome {
+    attempted: usize,
+    passed: usize,
+    failed: usize,
+    first_fail: Option<usize>,
+}
+fn replay_from(
+    rec: &Recording,
+    start: usize,
+    stop_on_fail: bool,
+    reset_each_tick: bool,
+) -> Outcome {
+    if let Ok(v) = env::var("RSIM_DEBUG_ONLY_START") {
+        if v.parse::<usize>().ok() != Some(start) {
+            return Outcome {
+                attempted: 0,
+                passed: 0,
+                failed: 0,
+                first_fail: None,
+            };
+        }
+    }
+    let (mut arena, ids) = add_arena(rec.num_cars);
+    let initial = &rec.ticks[start];
+    for c in 0..rec.num_cars {
+        set_car(
+            &mut arena,
+            ids[c],
+            &initial.cars[c],
+            initial.cars[c].prev_controls,
+        );
+    }
+    set_ball(&mut arena, &initial.ball);
+    arena.step_tick();
+    for c in 0..rec.num_cars {
+        set_car(
+            &mut arena,
+            ids[c],
+            &initial.cars[c],
+            rec.ticks[start + 1].cars[c].prev_controls,
+        );
+    }
+    set_ball(&mut arena, &initial.ball);
+    let mut out = Outcome {
+        attempted: 0,
+        passed: 0,
+        failed: 0,
+        first_fail: None,
+    };
+    for i in start..rec.ticks.len() - 1 {
+        let from = &rec.ticks[i];
+        let to = &rec.ticks[i + 1];
+        if to.cars[0].phys.physics_frame - from.cars[0].phys.physics_frame != 1 {
+            break;
+        }
+        if reset_each_tick {
+            for c in 0..rec.num_cars {
+                set_car(&mut arena, ids[c], &from.cars[c], to.cars[c].prev_controls);
+            }
+            set_ball(&mut arena, &from.ball);
+        } else {
+            for c in 0..rec.num_cars {
+                arena.set_car_controls(ids[c], controls(to.cars[c].prev_controls));
+            }
+        }
+        arena.step_tick();
+        out.attempted += 1;
+        if env::var("RSIM_TRACE_START")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            == Some(start)
+            && (env::var("RSIM_TRACE_ALL").is_ok() || out.attempted <= 20)
+        {
+            for (c, &id) in ids.iter().enumerate() {
+                let p = arena.get_car_state(id);
+                print!("trace,{},{}", i + 1, c);
+                for x in [
+                    p.phys.pos.x,
+                    p.phys.pos.y,
+                    p.phys.pos.z,
+                    p.phys.vel.x,
+                    p.phys.vel.y,
+                    p.phys.vel.z,
+                    p.phys.ang_vel.x,
+                    p.phys.ang_vel.y,
+                    p.phys.ang_vel.z,
+                    p.phys.rot_mat.x_axis.x,
+                    p.phys.rot_mat.x_axis.y,
+                    p.phys.rot_mat.x_axis.z,
+                    p.phys.rot_mat.z_axis.x,
+                    p.phys.rot_mat.z_axis.y,
+                    p.phys.rot_mat.z_axis.z,
+                ] {
+                    print!(",{x:.9}");
+                }
+                print!(
+                    ",{},{},{},{},{:.9},{:.9}",
+                    p.is_flipping as u8,
+                    p.is_jumping as u8,
+                    p.has_jumped as u8,
+                    p.has_flipped as u8,
+                    p.flip_time,
+                    p.air_time_since_jump
+                );
+                println!();
+            }
+        }
+        if compare_tick(&arena, &ids, to) < 1.0 {
+            out.passed += 1;
+        } else {
+            out.failed += 1;
+            if out.first_fail.is_none() {
+                out.first_fail = Some(i + 1);
+                if env::var("RSIM_DEBUG_START")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    == Some(start)
+                {
+                    println!(
+                        "debug_first_fail,start={},transition={},norm={}",
+                        start,
+                        i,
+                        compare_tick(&arena, &ids, to)
+                    );
+                    for (c, &id) in ids.iter().enumerate() {
+                        let p = arena.get_car_state(id);
+                        let r = &to.cars[c];
+                        println!(
+                            "debug_car={},pred_pos={:?},rec_pos={:?},pred_vel={:?},rec_vel={:?},pred_ang={:?},rec_ang={:?},pred_forward={:?},rec_forward={:?},pred_up={:?},rec_up={:?},pred_ground={},rec_ground={},pred_jump={},rec_jump={},pred_has_jump={},rec_has_jump={}",
+                            c,
+                            p.phys.pos,
+                            v(r.phys.pos),
+                            p.phys.vel,
+                            v(r.phys.lin_vel),
+                            p.phys.ang_vel,
+                            v(r.phys.ang_vel),
+                            p.get_forward_dir(),
+                            v(r.phys.rot.column(0)),
+                            p.get_up_dir(),
+                            v(r.phys.rot.column(2)),
+                            p.is_on_ground,
+                            r.is_on_ground,
+                            p.is_jumping,
+                            r.is_jumping,
+                            p.has_jumped,
+                            r.has_jumped
+                        );
+                    }
+                    let p = arena.get_ball_state();
+                    println!(
+                        "debug_ball,pred_pos={:?},rec_pos={:?},pred_vel={:?},rec_vel={:?},pred_ang={:?},rec_ang={:?},pred_forward={:?},rec_forward={:?},pred_up={:?},rec_up={:?}",
+                        p.phys.pos,
+                        v(to.ball.pos),
+                        p.phys.vel,
+                        v(to.ball.lin_vel),
+                        p.phys.ang_vel,
+                        v(to.ball.ang_vel),
+                        p.get_forward_dir(),
+                        v(to.ball.rot.column(0)),
+                        p.get_up_dir(),
+                        v(to.ball.rot.column(2))
+                    );
+                }
+            }
+            if stop_on_fail {
+                break;
+            }
+        }
+        if env::var("RSIM_DEBUG_TICKS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .is_some_and(|n| out.attempted >= n)
+        {
+            break;
+        }
+    }
+    out
+}
+
+fn splitmix(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+fn starts(limit: usize, count: usize, seed: u64) -> Vec<usize> {
+    let mut set = HashSet::new();
+    let mut s = seed;
+    while set.len() < count.min(limit) {
+        set.insert((splitmix(&mut s) as usize) % limit);
+    }
+    let mut v: Vec<_> = set.into_iter().collect();
+    v.sort_unstable();
+    v
+}
+fn percentile(v: &[usize], p: f64) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    let mut x = v.to_vec();
+    x.sort_unstable();
+    let q = p * (x.len() - 1) as f64;
+    let lo = q.floor() as usize;
+    let hi = (lo + 1).min(x.len() - 1);
+    x[lo] as f64 + (q - lo as f64) * (x[hi] - x[lo]) as f64
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    assert!(
+        args.len() >= 2,
+        "usage: best_random_benchmark <recording.rlpr>"
+    );
+    rocketsim::init_from_default(true).expect("RocketSim init");
+    let rec = parse(&args[1]);
+    let seed = 0xD1A2B3C4E5F60718u64;
+    let sample_count = env::var("RSIM_SAMPLE_COUNT")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1000);
+    let ss = starts(rec.ticks.len() - 1, sample_count, seed);
+    if let Ok(start) = env::var("RSIM_DEBUG_START") {
+        println!("debug_start,{}", start);
+    }
+    println!(
+        "engine,v3_rust\nrecording,{}\nticks,{}\ncars,{}\nsample_seed,{}\nsamples,{}",
+        args[1],
+        rec.ticks.len(),
+        rec.num_cars,
+        seed,
+        ss.len()
+    );
+    println!(
+        "sample,start_record_idx,start_physics_frame,first_divergence_record_idx,tick_before_divergence,ticks_before_divergence,pass_to_end"
+    );
+    let mut survived = Vec::with_capacity(ss.len());
+    let mut sample_pass = 0usize;
+    for (n, &start) in ss.iter().enumerate() {
+        let o = replay_from(&rec, start, env::var("RSIM_TRACE_START").is_err(), false);
+        let pass = o.failed == 0;
+        if pass {
+            sample_pass += 1;
+        }
+        survived.push(o.passed);
+        let before = o.first_fail.map(|i| i - 1);
+        match o.first_fail {
+            Some(i) => println!(
+                "{n},{start},{},{i},{},{},0",
+                rec.ticks[start].cars[0].phys.physics_frame,
+                before.unwrap(),
+                o.passed
+            ),
+            None => println!(
+                "{n},{start},{},-,-,{},1",
+                rec.ticks[start].cars[0].phys.physics_frame, o.passed
+            ),
+        }
+    }
+    let full = replay_from(&rec, 0, false, false);
+    let pct = 100.0 * full.passed as f64 / full.attempted.max(1) as f64;
+    let reset = if env::var("RSIM_SKIP_RESET").is_ok() {
+        Outcome {
+            attempted: 0,
+            passed: 0,
+            failed: 0,
+            first_fail: None,
+        }
+    } else {
+        replay_from(&rec, 0, false, true)
+    };
+    let reset_pct = 100.0 * reset.passed as f64 / reset.attempted.max(1) as f64;
+    println!(
+        "random_mean_ticks_before_divergence,{}",
+        survived.iter().sum::<usize>() as f64 / survived.len().max(1) as f64
+    );
+    println!(
+        "random_median_ticks_before_divergence,{}",
+        percentile(&survived, 0.5)
+    );
+    println!(
+        "random_p90_ticks_before_divergence,{}",
+        percentile(&survived, 0.9)
+    );
+    println!(
+        "random_min_ticks_before_divergence,{}",
+        survived.iter().min().unwrap_or(&0)
+    );
+    println!(
+        "random_max_ticks_before_divergence,{}",
+        survived.iter().max().unwrap_or(&0)
+    );
+    println!(
+        "random_01_pass_rate,{}",
+        100.0 * sample_pass as f64 / ss.len().max(1) as f64
+    );
+    println!(
+        "full_attempted_frames,{}\nfull_passed_frames,{}\nfull_failed_frames,{}\nfull_frame_pass_rate,{}\nfull_recording_01,{}\nreset_attempted_frames,{}\nreset_passed_frames,{}\nreset_failed_frames,{}\nreset_frame_pass_rate,{}\nreset_recording_01,{}",
+        full.attempted,
+        full.passed,
+        full.failed,
+        pct,
+        if full.failed == 0 { 1 } else { 0 },
+        reset.attempted,
+        reset.passed,
+        reset.failed,
+        reset_pct,
+        if reset.failed == 0 { 1 } else { 0 }
+    );
+}

--- a/rocketsim/examples/daizen_v3_rust_rlpr.rs
+++ b/rocketsim/examples/daizen_v3_rust_rlpr.rs
@@ -1,0 +1,548 @@
+//! Re-record a Daizen-vs-Daizen RLPR stream with RocketSim v3 Rust.
+//!
+//! The source tape contains the controls emitted by the two DaizenBotV1
+//! players.  This example uses those controls as the policy stream, runs the
+//! physics transitions in the Rust v3 engine, and writes a fresh RLPR file
+//! containing the v3-generated state frames.
+
+use std::{
+    env,
+    fs::{self, File},
+    io::{self, BufWriter, Write},
+    mem::size_of,
+    path::{Path, PathBuf},
+};
+
+use glam::{Mat3A, Vec3A};
+use rocketsim::{
+    Arena, CarBodyConfig, CarControls, CarState, GameMode, PhysState, Team, consts::TICK_RATE,
+    init_from_default,
+};
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct VecRecord {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Mat3Record {
+    rows: [VecRecord; 3],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct WheelRecord {
+    susp_length: f32,
+    susp_rel_vel: f32,
+    has_contact: bool,
+    contact_normal: VecRecord,
+    steer_amount: f32,
+    engine_force: f32,
+    brake: f32,
+    lat_friction: f32,
+    long_friction: f32,
+    extra_pushback: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ControlsRecord {
+    throttle: f32,
+    steer: f32,
+    pitch: f32,
+    yaw: f32,
+    roll: f32,
+    jump: bool,
+    boost: bool,
+    handbrake: bool,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone)]
+enum ImpulseRecordType {
+    WheelsSuspension = 0,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ImpulseRecord {
+    lin_impulse: VecRecord,
+    ang_impulse: VecRecord,
+    impulse_type: ImpulseRecordType,
+    is_accum: bool,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct PhysRecord {
+    physics_frame: u32,
+    pos: VecRecord,
+    rot: Mat3Record,
+    lin_vel: VecRecord,
+    ang_vel: VecRecord,
+    has_world_contact: bool,
+    world_contact_point: VecRecord,
+    world_contact_normal: VecRecord,
+    impulse_records_data: [ImpulseRecord; 8],
+    num_impulse_records: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct CarRecord {
+    phys: PhysRecord,
+    is_on_ground: bool,
+    is_jumping: bool,
+    is_flipping: bool,
+    jump_time: f32,
+    flip_time: f32,
+    has_jumped: bool,
+    double_jumped_or_flipped: bool,
+    has_flip: bool,
+    flip_rel_torque: VecRecord,
+    boost_amount: f32,
+    is_touching_ball: bool,
+    prev_controls: ControlsRecord,
+    wheels: [WheelRecord; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct RecInfo {
+    num_cars: u32,
+    hitbox_rel_min_bt: VecRecord,
+    hitbox_rel_max_bt: VecRecord,
+}
+
+#[derive(Clone)]
+struct SourceTick {
+    cars: Vec<CarRecord>,
+    ball: PhysRecord,
+}
+
+struct SourceRecording {
+    info: RecInfo,
+    ticks: Vec<SourceTick>,
+}
+
+struct Reader {
+    bytes: Vec<u8>,
+    offset: usize,
+}
+
+impl Reader {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, count: usize) -> &[u8] {
+        let end = self
+            .offset
+            .checked_add(count)
+            .expect("RLPR offset overflow");
+        assert!(end <= self.bytes.len(), "truncated RLPR recording");
+        let start = self.offset;
+        self.offset = end;
+        &self.bytes[start..end]
+    }
+
+    fn u8(&mut self) -> u8 {
+        self.take(1)[0]
+    }
+
+    fn u32(&mut self) -> u32 {
+        u32::from_le_bytes(self.take(4).try_into().unwrap())
+    }
+
+    fn pod<T: Copy>(&mut self) -> T {
+        let bytes = self.take(size_of::<T>());
+        // All RLPR structs are #[repr(C)] and the file is little-endian.
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr().cast::<T>()) }
+    }
+}
+
+fn read_size_prefixed<T: Copy>(reader: &mut Reader) -> T {
+    let serialized_size = reader.u32() as usize;
+    assert_eq!(
+        serialized_size,
+        size_of::<T>(),
+        "RLPR struct-size mismatch (serialized {serialized_size}, local {})",
+        size_of::<T>()
+    );
+    reader.pod()
+}
+
+fn read_source(path: &Path) -> SourceRecording {
+    assert_eq!(size_of::<PhysRecord>(), 332);
+    assert_eq!(size_of::<CarRecord>(), 584);
+    assert_eq!(size_of::<ControlsRecord>(), 24);
+    assert_eq!(size_of::<RecInfo>(), 28);
+
+    let mut reader = Reader::new(
+        fs::read(path)
+            .unwrap_or_else(|e| panic!("cannot read source RLPR {}: {e}", path.display())),
+    );
+    assert_eq!(reader.take(4), b"RLPR", "source is not an RLPR file");
+    assert_eq!(reader.u8(), 0, "source RLPR is not little-endian");
+    assert_eq!(reader.u32(), 2, "source RLPR version is not 2");
+    assert_eq!(reader.u32() as usize, size_of::<RecInfo>());
+    let info: RecInfo = reader.pod();
+    assert_eq!(
+        info.num_cars, 2,
+        "Daizen self-play source must contain two cars"
+    );
+
+    let num_ticks = reader.u32() as usize;
+    let mut ticks = Vec::with_capacity(num_ticks);
+    for _ in 0..num_ticks {
+        let mut cars = Vec::with_capacity(info.num_cars as usize);
+        for _ in 0..info.num_cars {
+            cars.push(read_size_prefixed(&mut reader));
+        }
+        let ball = read_size_prefixed(&mut reader);
+        ticks.push(SourceTick { cars, ball });
+    }
+    assert_eq!(
+        reader.offset,
+        reader.bytes.len(),
+        "source RLPR has trailing bytes"
+    );
+    SourceRecording { info, ticks }
+}
+
+fn vec_record(v: Vec3A) -> VecRecord {
+    VecRecord {
+        x: v.x,
+        y: v.y,
+        z: v.z,
+    }
+}
+
+fn vec3(v: VecRecord) -> Vec3A {
+    Vec3A::new(v.x, v.y, v.z)
+}
+
+fn phys_from_record(record: PhysRecord) -> PhysState {
+    PhysState {
+        pos: vec3(record.pos),
+        rot_mat: Mat3A::from_cols(
+            vec3(VecRecord {
+                x: record.rot.rows[0].x,
+                y: record.rot.rows[1].x,
+                z: record.rot.rows[2].x,
+            }),
+            vec3(VecRecord {
+                x: record.rot.rows[0].y,
+                y: record.rot.rows[1].y,
+                z: record.rot.rows[2].y,
+            }),
+            vec3(VecRecord {
+                x: record.rot.rows[0].z,
+                y: record.rot.rows[1].z,
+                z: record.rot.rows[2].z,
+            }),
+        ),
+        vel: vec3(record.lin_vel),
+        ang_vel: vec3(record.ang_vel),
+    }
+}
+
+fn controls_from_record(record: ControlsRecord) -> CarControls {
+    CarControls {
+        throttle: record.throttle,
+        steer: record.steer,
+        pitch: record.pitch,
+        yaw: record.yaw,
+        roll: record.roll,
+        jump: record.jump,
+        boost: record.boost,
+        handbrake: record.handbrake,
+    }
+}
+
+fn controls_record(controls: CarControls) -> ControlsRecord {
+    ControlsRecord {
+        throttle: controls.throttle,
+        steer: controls.steer,
+        pitch: controls.pitch,
+        yaw: controls.yaw,
+        roll: controls.roll,
+        jump: controls.jump,
+        boost: controls.boost,
+        handbrake: controls.handbrake,
+    }
+}
+
+fn car_state_from_source(record: &CarRecord, controls: CarControls) -> CarState {
+    let mut state = CarState::default();
+    state.phys = phys_from_record(record.phys);
+    state.controls = controls;
+    state.prev_controls = controls_from_record(record.prev_controls);
+    state.is_on_ground = record.is_on_ground;
+    state.is_jumping = record.is_jumping;
+    state.is_flipping = record.is_flipping;
+    state.jump_ticks = (record.jump_time * TICK_RATE).round() as u32;
+    state.flip_time = record.flip_time;
+    state.has_jumped = record.has_jumped;
+    state.has_double_jumped = record.double_jumped_or_flipped;
+    state.has_flipped = record.has_flip;
+    state.flip_rel_torque = vec3(record.flip_rel_torque);
+    state.boost = record.boost_amount;
+    state.wheels_with_contact = record.wheels.map(|wheel| wheel.has_contact);
+    state.world_contact_normal = record
+        .phys
+        .has_world_contact
+        .then(|| vec3(record.phys.world_contact_normal));
+    state
+}
+
+fn set_source_state(
+    arena: &mut Arena,
+    car_ids: &[usize],
+    tick: &SourceTick,
+    controls: &[CarControls],
+) {
+    for (i, &car_id) in car_ids.iter().enumerate() {
+        arena.set_car_state(car_id, car_state_from_source(&tick.cars[i], controls[i]));
+    }
+    let mut ball = *arena.get_ball_state();
+    ball.phys = phys_from_record(tick.ball);
+    arena.set_ball_state(ball);
+}
+
+fn empty_phys(frame: u32, state: &PhysState) -> PhysRecord {
+    let f = state.rot_mat.x_axis;
+    let r = state.rot_mat.y_axis;
+    let u = state.rot_mat.z_axis;
+    let mut record: PhysRecord = unsafe { std::mem::zeroed() };
+    record.physics_frame = frame;
+    record.pos = vec_record(state.pos);
+    record.rot = Mat3Record {
+        rows: [
+            VecRecord {
+                x: f.x,
+                y: r.x,
+                z: u.x,
+            },
+            VecRecord {
+                x: f.y,
+                y: r.y,
+                z: u.y,
+            },
+            VecRecord {
+                x: f.z,
+                y: r.z,
+                z: u.z,
+            },
+        ],
+    };
+    record.lin_vel = vec_record(state.vel);
+    record.ang_vel = vec_record(state.ang_vel);
+    record.has_world_contact = false;
+    record
+}
+
+fn car_record_from_state(arena: &Arena, car_id: usize, frame: u32) -> CarRecord {
+    let state = arena.get_car_state(car_id);
+    let mut record: CarRecord = unsafe { std::mem::zeroed() };
+    record.phys = empty_phys(frame, &state.phys);
+    record.is_on_ground = state.is_on_ground;
+    record.is_jumping = state.is_jumping;
+    record.is_flipping = state.is_flipping;
+    record.jump_time = state.jump_time();
+    record.flip_time = state.flip_time;
+    record.has_jumped = state.has_jumped;
+    record.double_jumped_or_flipped = state.has_double_jumped;
+    record.has_flip = state.has_flipped;
+    record.flip_rel_torque = vec_record(state.flip_rel_torque);
+    record.boost_amount = state.boost;
+    record.is_touching_ball = false;
+    record.prev_controls = controls_record(state.prev_controls);
+
+    for (i, (contact, susp, rel_vel)) in arena.get_car_wheel_debug(car_id).into_iter().enumerate() {
+        record.wheels[i].has_contact = contact;
+        record.wheels[i].susp_length = susp;
+        record.wheels[i].susp_rel_vel = rel_vel;
+    }
+    record
+}
+
+fn write_pod<T: Copy>(writer: &mut BufWriter<File>, value: &T) -> io::Result<()> {
+    let bytes =
+        unsafe { std::slice::from_raw_parts((value as *const T).cast::<u8>(), size_of::<T>()) };
+    writer.write_all(bytes)
+}
+
+fn write_u8(writer: &mut BufWriter<File>, value: u8) -> io::Result<()> {
+    writer.write_all(&[value])
+}
+
+fn write_u32(writer: &mut BufWriter<File>, value: u32) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn write_size_prefixed<T: Copy>(writer: &mut BufWriter<File>, value: &T) -> io::Result<()> {
+    write_u32(writer, size_of::<T>() as u32)?;
+    write_pod(writer, value)
+}
+
+fn write_metadata(
+    output: &Path,
+    source: &Path,
+    source_ticks: usize,
+    output_bytes: u64,
+    final_frame: u32,
+) -> io::Result<()> {
+    let directory = output.parent().unwrap_or_else(|| Path::new("."));
+    let metadata = directory.join("DaizenVsDaizen_RocketSimV3Rust.md");
+    let text = format!(
+        "# Daizen vs Daizen — RocketSim v3 Rust\n\n\
+Engine: RocketSim v3 Rust (`rocketsim` crate)\n\
+Players: Blue DaizenBotV1 vs Orange DaizenBotV1\n\
+State frames: simulated and serialized by the Rust v3 engine\n\
+Policy controls: copied from the verified Daizen-vs-Daizen source tape `{}`\n\
+Source control ticks: {}\n\
+Output ticks: {}\n\
+Final physics frame: {}\n\
+RLPR bytes: {}\n\n\
+The source tape supplies the two Daizen action streams; this file replays those\
+actions through RocketSim v3 Rust and records the resulting state at every tick.\n",
+        source.display(),
+        source_ticks,
+        source_ticks,
+        final_frame,
+        output_bytes
+    );
+    fs::write(metadata, text)
+}
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: daizen_v3_rust_rlpr <source_controls.rlpr> <output.rlpr> [max_ticks]");
+        return Ok(());
+    }
+    let source = PathBuf::from(&args[1]);
+    let output = PathBuf::from(&args[2]);
+    let max_ticks = args.get(3).map(|value| {
+        value
+            .parse::<usize>()
+            .unwrap_or_else(|_| panic!("invalid max tick count: {value}"))
+    });
+
+    let source_recording = read_source(&source);
+    let num_ticks = max_ticks
+        .unwrap_or(source_recording.ticks.len())
+        .min(source_recording.ticks.len());
+    assert!(num_ticks >= 2, "recording must contain at least two ticks");
+
+    init_from_default(true).expect("RocketSim v3 initialization failed");
+    let mut arena = Arena::new(GameMode::Soccar);
+    let car_ids = vec![
+        arena.add_car(Team::Blue, CarBodyConfig::OCTANE),
+        arena.add_car(Team::Orange, CarBodyConfig::OCTANE),
+    ];
+
+    // Match the v3 comparison harness: one warm-up establishes contact caches,
+    // then the initial source state is restored before the first real action.
+    let warmup_controls: Vec<CarControls> = source_recording.ticks[0]
+        .cars
+        .iter()
+        .map(|car| controls_from_record(car.prev_controls))
+        .collect();
+    set_source_state(
+        &mut arena,
+        &car_ids,
+        &source_recording.ticks[0],
+        &warmup_controls,
+    );
+    arena.step_tick();
+
+    let first_controls: Vec<CarControls> = source_recording.ticks[1]
+        .cars
+        .iter()
+        .map(|car| controls_from_record(car.prev_controls))
+        .collect();
+    set_source_state(
+        &mut arena,
+        &car_ids,
+        &source_recording.ticks[0],
+        &first_controls,
+    );
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let temp = output.with_extension("rlpr.tmp");
+    let file = File::create(&temp)?;
+    let mut writer = BufWriter::with_capacity(1 << 20, file);
+    writer.write_all(b"RLPR")?;
+    write_u8(&mut writer, 0)?;
+    write_u32(&mut writer, 2)?;
+    write_u32(&mut writer, size_of::<RecInfo>() as u32)?;
+    write_pod(&mut writer, &source_recording.info)?;
+    write_u32(&mut writer, num_ticks as u32)?;
+
+    let mut frame = 0u32;
+    for i in 0..num_ticks {
+        for &car_id in &car_ids {
+            let record = car_record_from_state(&arena, car_id, frame);
+            write_size_prefixed(&mut writer, &record)?;
+        }
+        let ball_record = empty_phys(frame, &arena.get_ball_state().phys);
+        write_size_prefixed(&mut writer, &ball_record)?;
+
+        if i + 1 == num_ticks {
+            break;
+        }
+
+        let next_controls: Vec<CarControls> = source_recording.ticks[i + 1]
+            .cars
+            .iter()
+            .map(|car| controls_from_record(car.prev_controls))
+            .collect();
+        for (idx, &car_id) in car_ids.iter().enumerate() {
+            arena.set_car_controls(car_id, next_controls[idx]);
+        }
+
+        let source_frame = source_recording.ticks[i].cars[0].phys.physics_frame;
+        let next_source_frame = source_recording.ticks[i + 1].cars[0].phys.physics_frame;
+        let frame_delta = next_source_frame.saturating_sub(source_frame);
+        if frame_delta == 1 {
+            arena.step_tick();
+        } else {
+            // Goal/reset transitions are represented by a deliberate frame
+            // gap in RLPR. Keep the gap and start a fresh Rust kickoff.
+            arena.reset_to_random_kickoff(Some(0xDA1CE_u64.wrapping_add(i as u64)));
+            for (idx, &car_id) in car_ids.iter().enumerate() {
+                arena.set_car_controls(car_id, next_controls[idx]);
+            }
+        }
+        frame = frame.wrapping_add(frame_delta.max(1));
+
+        if (i + 1) % 1200 == 0 || i + 1 == num_ticks - 1 {
+            eprintln!("recorded {}/{} ticks", i + 1, num_ticks);
+        }
+    }
+
+    writer.flush()?;
+    drop(writer);
+    if output.exists() {
+        fs::remove_file(&output)?;
+    }
+    fs::rename(&temp, &output)?;
+    let bytes = fs::metadata(&output)?.len();
+    write_metadata(&output, &source, source_recording.ticks.len(), bytes, frame)?;
+    eprintln!(
+        "finished: {} ticks, {} bytes, final physics frame {}, output {}",
+        num_ticks,
+        bytes,
+        frame,
+        output.display()
+    );
+    Ok(())
+}

--- a/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/compound_collision_alg.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::{
     bullet::{
         collision::{
+            narrowphase::gjk::{ClosestPointInput, GjkPairDetector, GjkResult},
             narrowphase::persistent_manifold::{ContactAddedCallback, PersistentManifold},
             shapes::{
                 box_shape::BoxShape, collision_shape::CollisionShapes,
@@ -21,16 +22,54 @@ use crate::{
     shared::{Aabb, rsmath},
 };
 
+#[derive(Clone, Copy)]
 struct SatResult {
     penetration: f32,
     axis: Vec3A,
     axis_type: AxisType,
 }
 
+#[derive(Clone, Copy)]
 enum AxisType {
     TriFace,
     ObbFace(usize),
     EdgeEdge { box_axis: usize, tri_edge: usize },
+}
+
+struct NoopGjkResult;
+
+impl GjkResult for NoopGjkResult {
+    fn add_contact_point(&mut self, _normal_on_b: Vec3A, _point_on_b_world: Vec3A, _depth: f32) {}
+}
+
+fn clip_polygon_against_plane(
+    input: &[Vec3A],
+    normal: Vec3A,
+    plane_eq: f32,
+) -> ArrayVec<Vec3A, 16> {
+    let mut output = ArrayVec::new();
+    if input.len() < 2 {
+        return output;
+    }
+
+    let mut first = *input.last().unwrap();
+    let mut ds = normal.dot(first) + plane_eq;
+    for &end in input {
+        let de = normal.dot(end) + plane_eq;
+        if ds < 0.0 {
+            if de < 0.0 {
+                output.push(end);
+            } else {
+                output.push(first.lerp(end, ds / (ds - de)));
+            }
+        } else if de < 0.0 {
+            output.push(first.lerp(end, ds / (ds - de)));
+            output.push(end);
+        }
+        first = end;
+        ds = de;
+    }
+    output
 }
 
 struct ConvexTriangleCallback<'a, T: ContactAddedCallback> {
@@ -39,14 +78,37 @@ struct ConvexTriangleCallback<'a, T: ContactAddedCallback> {
     pub tri_obj: &'a RigidBody,
     pub local_convex_aabb: &'a Aabb,
     pub box_shape: &'a BoxShape,
+    pub gjk_shape: Option<&'a CollisionShapes>,
+    pub convex_world_trans: Affine3A,
+    pub current_triangle_index: usize,
     pub contact_added_callback: &'a mut T,
 }
 
+impl<T: ContactAddedCallback> GjkResult for ConvexTriangleCallback<'_, T> {
+    fn add_contact_point(&mut self, normal_on_b: Vec3A, point_on_b_world: Vec3A, depth: f32) {
+        self.manifold.add_contact_point(
+            self.convex_obj.obj,
+            self.tri_obj,
+            normal_on_b,
+            point_on_b_world,
+            depth,
+            Some(self.current_triangle_index),
+            self.contact_added_callback,
+        );
+    }
+}
+
 impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> {
+    fn stable_triangle_order(&self) -> bool {
+        true
+    }
+
     fn process_triangle(&mut self, triangle: &TriangleShape, triangle_idx: usize) {
         if !triangle.aabb().intersects(self.local_convex_aabb) {
             return;
         }
+
+        self.current_triangle_index = triangle_idx;
 
         let half_extents = self.box_shape.get_half_extents();
         let contact_margin = self.box_shape.get_margin() + self.manifold.contact_breaking_threshold;
@@ -172,6 +234,129 @@ impl<T: ContactAddedCallback> ProcessTriangle for ConvexTriangleCallback<'_, T> 
         let Some(result) = best_result else {
             return;
         };
+
+        // Diagnostic escape hatch: the legacy SAT contact construction is useful
+        // when comparing the narrowphase against Bullet's per-triangle GJK.
+        // It is disabled by default and must never affect normal runs.
+        if let Some(gjk_shape) = self.gjk_shape {
+            if std::env::var_os("RSIM_COMPOUND_SAT").is_some() {
+                // Diagnostic only: continue with the legacy SAT contact below.
+            } else if std::env::var_os("RSIM_CLIP_TRIANGLES").is_some() {
+                let triangle_shape = CollisionShapes::Triangle(*triangle);
+                let convex_world_trans = self.convex_world_trans;
+                let contact_breaking_threshold = self.manifold.contact_breaking_threshold;
+                let input = ClosestPointInput::new(
+                    &convex_world_trans,
+                    self.tri_obj.get_world_trans(),
+                    self.box_shape.get_margin() + contact_breaking_threshold,
+                );
+                let mut noop = NoopGjkResult;
+                let (cached_axis, cached_distance, found_contact) =
+                    GjkPairDetector::new(self.box_shape.get_margin(), 0.0)
+                        .get_closest_points_with_cache(
+                            &input,
+                            gjk_shape,
+                            &triangle_shape,
+                            &mut noop,
+                        );
+
+                if !found_contact || cached_axis.length_squared() <= f32::EPSILON {
+                    return;
+                }
+
+                // Match Bullet's polyhedral-vs-triangle path: GJK supplies the
+                // separating direction, then the triangle is clipped against the
+                // incident box face and all resulting contacts are emitted.
+                let sep_normal = cached_axis / cached_axis.length_squared();
+                let min_dist = cached_distance - self.box_shape.get_margin();
+                let min_clip = min_dist - self.manifold.contact_breaking_threshold;
+                let max_clip = self.manifold.contact_breaking_threshold;
+                let tri_world_trans = self.tri_obj.get_world_trans();
+                let inv_box = convex_world_trans.inverse();
+                let tri_local = [
+                    inv_box
+                        .transform_point3a(tri_world_trans.transform_point3a(triangle.points[0])),
+                    inv_box
+                        .transform_point3a(tri_world_trans.transform_point3a(triangle.points[1])),
+                    inv_box
+                        .transform_point3a(tri_world_trans.transform_point3a(triangle.points[2])),
+                ];
+                let full_half =
+                    self.box_shape.get_half_extents() + Vec3A::splat(self.box_shape.get_margin());
+
+                let mut face_axis = 0usize;
+                let mut face_sign = 1.0f32;
+                let mut face_dot = f32::INFINITY;
+                for axis in 0..3 {
+                    for sign in [-1.0f32, 1.0] {
+                        let mut local_normal = Vec3A::ZERO;
+                        local_normal[axis] = sign;
+                        let world_face_normal = convex_world_trans.transform_vector3a(local_normal);
+                        let dot = world_face_normal.dot(sep_normal);
+                        if dot < face_dot {
+                            face_dot = dot;
+                            face_axis = axis;
+                            face_sign = sign;
+                        }
+                    }
+                }
+
+                let mut polygon = ArrayVec::<Vec3A, 16>::new();
+                polygon.extend(tri_local);
+                for axis in 0..3 {
+                    if axis == face_axis {
+                        continue;
+                    }
+                    for sign in [-1.0f32, 1.0] {
+                        let mut plane_normal = Vec3A::ZERO;
+                        plane_normal[axis] = sign;
+                        polygon =
+                            clip_polygon_against_plane(&polygon, plane_normal, -full_half[axis]);
+                        if polygon.is_empty() {
+                            return;
+                        }
+                    }
+                }
+
+                let mut face_normal_local = Vec3A::ZERO;
+                face_normal_local[face_axis] = face_sign;
+                let face_plane = -full_half[face_axis];
+                for point_local in polygon {
+                    let mut depth = face_normal_local.dot(point_local) + face_plane;
+                    if depth <= min_clip {
+                        depth = min_clip;
+                    }
+                    if depth <= max_clip {
+                        let point_world = convex_world_trans.transform_point3a(point_local);
+                        self.manifold.add_contact_point(
+                            self.convex_obj.obj,
+                            self.tri_obj,
+                            sep_normal,
+                            point_world,
+                            depth,
+                            Some(triangle_idx),
+                            self.contact_added_callback,
+                        );
+                    }
+                }
+                return;
+            } else {
+                let triangle_shape = CollisionShapes::Triangle(*triangle);
+                let convex_world_trans = self.convex_world_trans;
+                let input = ClosestPointInput::new(
+                    &convex_world_trans,
+                    self.tri_obj.get_world_trans(),
+                    self.box_shape.get_margin() + self.manifold.contact_breaking_threshold,
+                );
+                GjkPairDetector::new(self.box_shape.get_margin(), 0.0).get_closest_points(
+                    &input,
+                    gjk_shape,
+                    &triangle_shape,
+                    self,
+                );
+                return;
+            }
+        }
 
         let contact_point_local = match result.axis_type {
             AxisType::TriFace => {
@@ -311,6 +496,7 @@ pub fn process_collision<T: ContactAddedCallback>(
 
     match other_col_shape {
         CollisionShapes::TriangleMesh(tri_mesh) => {
+            let gjk_shape = compound_shape.gjk_shape.as_ref();
             let xform1 = other_obj.get_world_trans().transpose();
             let xform2 = new_child_world_trans;
             let convex_in_triangle_space = Affine3A {
@@ -325,6 +511,9 @@ pub fn process_collision<T: ContactAddedCallback>(
                 tri_obj: other_obj,
                 local_convex_aabb: &aabb_in_triangle,
                 box_shape,
+                gjk_shape: Some(gjk_shape),
+                convex_world_trans: new_child_world_trans,
+                current_triangle_index: 0,
                 contact_added_callback,
             };
 

--- a/rocketsim/src/bullet/collision/dispatch/convex_plane_collision_alg.rs
+++ b/rocketsim/src/bullet/collision/dispatch/convex_plane_collision_alg.rs
@@ -4,6 +4,7 @@ use super::collision_obj_wrapper::RigidBodyWrapper;
 use crate::bullet::{
     collision::{
         narrowphase::persistent_manifold::{ContactAddedCallback, PersistentManifold},
+        shapes::collision_shape::CollisionShapes,
         shapes::static_plane_shape::StaticPlaneShape,
     },
     dynamics::rigid_body::RigidBody,
@@ -35,7 +36,38 @@ pub fn process_collision<T: ContactAddedCallback>(
     let distance = plane_normal.dot(vtx_in_plane);
 
     let mut manifold = PersistentManifold::new(convex_obj.obj, plane_obj);
-    if distance >= manifold.contact_breaking_threshold {
+    if std::env::var("RSIM_DEBUG_SPECIAL_DETAIL").is_ok()
+        && convex_obj.world_trans.translation.x > -11.0
+        && convex_obj.world_trans.translation.x < -9.0
+        && convex_obj.world_trans.translation.y > 79.0
+        && convex_obj.world_trans.translation.y < 81.0
+        && convex_obj.world_trans.translation.z < 3.0
+    {
+        println!(
+            "rust_plane_detail,body={},pos={:?},vtx={:?},distance={},threshold={}",
+            convex_obj.obj.world_array_idx,
+            convex_obj.world_trans.translation,
+            vtx,
+            distance,
+            manifold.contact_breaking_threshold,
+        );
+    }
+    // Bullet's convex-plane dispatcher evaluates the sphere/plane contact
+    // against the result-output distance margin as well as the manifold's
+    // breaking threshold.  On the V2 arena this keeps the ball's floor
+    // contact callback alive for a few extra 1e-5 BT while the ball is
+    // numerically grazing the plane.  Preserve the original signed distance
+    // in the manifold (so split-impulse penetration math is unchanged) and
+    // extend only the sphere threshold enough to cover that dispatcher margin.
+    let contact_threshold = if matches!(
+        convex_obj.obj.get_collision_shape(),
+        CollisionShapes::Sphere(_)
+    ) {
+        manifold.contact_breaking_threshold + 0.0001
+    } else {
+        manifold.contact_breaking_threshold
+    };
+    if distance >= contact_threshold {
         return None;
     }
 

--- a/rocketsim/src/bullet/collision/dispatch/quad_ray_callbacks.rs
+++ b/rocketsim/src/bullet/collision/dispatch/quad_ray_callbacks.rs
@@ -7,7 +7,7 @@ use crate::bullet::{
         shapes::{triangle_callback::ProcessQuadRayTriangle, triangle_shape::TriangleShape},
     },
     dynamics::rigid_body::RigidBody,
-    linear_math::interpolate_3,
+    linear_math::{bullet_normalize, interpolate_3},
 };
 
 pub struct LocalRayResult {
@@ -176,11 +176,17 @@ impl<T: QuadRayResultCallback> BridgeTriQuadRayCallback<'_, T> {
     }
 
     fn process_triangle(&mut self, triangle: &TriangleShape, lambda_max: &mut f32, ray_idx: usize) {
-        const EDGE_TOLERANCE: f32 = -0.0001;
-
-        let dist = triangle.points[0].dot(triangle.normal);
-        let dist_a = triangle.normal.dot(self.from[ray_idx]) - dist;
-        let dist_b = triangle.normal.dot(self.to[ray_idx]) - dist;
+        // Bullet computes the unnormalized triangle normal for the plane and
+        // edge tests on every raycast, and normalizes only the reported hit
+        // normal. Reusing the cached unit normal changes the hit fraction by a
+        // few ulps on arena mesh triangles and can make the coincident floor
+        // plane win the closest-hit tie.
+        let edge_0 = triangle.points[1] - triangle.points[0];
+        let edge_1 = triangle.points[2] - triangle.points[0];
+        let triangle_normal = edge_0.cross(edge_1);
+        let dist = triangle.points[0].dot(triangle_normal);
+        let dist_a = triangle_normal.dot(self.from[ray_idx]) - dist;
+        let dist_b = triangle_normal.dot(self.to[ray_idx]) - dist;
         if dist_a * dist_b >= 0.0 {
             return; // same sign
         }
@@ -195,27 +201,29 @@ impl<T: QuadRayResultCallback> BridgeTriQuadRayCallback<'_, T> {
         let point = self.from[ray_idx].lerp(self.to[ray_idx], distance);
         let v0p = triangle.points[0] - point;
         let v1p = triangle.points[1] - point;
+        let edge_tolerance = -0.0001 * triangle_normal.length_squared();
         let cp0 = v0p.cross(v1p);
-        if cp0.dot(triangle.normal) < EDGE_TOLERANCE {
+        if cp0.dot(triangle_normal) < edge_tolerance {
             return;
         }
 
         let v2p = triangle.points[2] - point;
         let cp1 = v1p.cross(v2p);
-        if cp1.dot(triangle.normal) < EDGE_TOLERANCE {
+        if cp1.dot(triangle_normal) < edge_tolerance {
             return;
         }
 
         let cp2 = v2p.cross(v0p);
-        if cp2.dot(triangle.normal) < EDGE_TOLERANCE {
+        if cp2.dot(triangle_normal) < edge_tolerance {
             return;
         }
 
         *lambda_max = distance;
+        let normal = bullet_normalize(triangle_normal);
         if dist_a <= 0.0 {
-            self.internal_report_hit(-triangle.normal, distance, ray_idx);
+            self.internal_report_hit(-normal, distance, ray_idx);
         } else {
-            self.internal_report_hit(triangle.normal, distance, ray_idx);
+            self.internal_report_hit(normal, distance, ray_idx);
         }
     }
 }

--- a/rocketsim/src/bullet/collision/narrowphase/gjk/gjk_pair_detector.rs
+++ b/rocketsim/src/bullet/collision/narrowphase/gjk/gjk_pair_detector.rs
@@ -5,6 +5,7 @@ use super::{
     solver::VoronoiSimplexSolver,
 };
 use crate::bullet::collision::shapes::collision_shape::CollisionShapes;
+use crate::bullet::linear_math::{bullet_dot, bullet_length_squared, bullet_normalize};
 
 const MAX_ITERATIONS: usize = 1000;
 const REL_ERROR2: f32 = 1.0e-6;
@@ -43,12 +44,25 @@ impl GjkPairDetector {
     }
 
     pub fn get_closest_points<T: GjkResult>(
-        mut self,
+        self,
         input: &ClosestPointInput,
         shape_a: &CollisionShapes,
         shape_b: &CollisionShapes,
         output: &mut T,
     ) {
+        let _ = self.get_closest_points_with_cache(input, shape_a, shape_b, output);
+    }
+
+    /// Run GJK/EPA and also return Bullet's cached separating axis/distance.
+    /// The convex-vs-triangle clipping path needs these values even though it
+    /// discards the detector's direct contact callback.
+    pub fn get_closest_points_with_cache<T: GjkResult>(
+        mut self,
+        input: &ClosestPointInput,
+        shape_a: &CollisionShapes,
+        shape_b: &CollisionShapes,
+        output: &mut T,
+    ) -> (Vec3A, f32, bool) {
         let mut local_trans_a = *input.transform_a;
         let mut local_trans_b = *input.transform_b;
         let position_offset = (local_trans_a.translation + local_trans_b.translation) * 0.5;
@@ -85,14 +99,17 @@ impl GjkPairDetector {
         let catch_degenerate_penetration_case =
             degenerate_simplex != 0 && (distance + self.margin) < 0.01;
 
-        if (!is_valid || catch_degenerate_penetration_case)
-            && let Some(result) = calc_pen_depth(shape_a, shape_b, &local_trans_a, &local_trans_b)
-        {
+        let penetration_result = if !is_valid || catch_degenerate_penetration_case {
+            calc_pen_depth(shape_a, shape_b, &local_trans_a, &local_trans_b)
+        } else {
+            None
+        };
+        if let Some(result) = penetration_result {
             let [tmp_point_on_a, tmp_point_on_b] = result.witnesses;
 
             if result.penetrating {
                 let tmp_normal_in_b = tmp_point_on_b - tmp_point_on_a;
-                let len_sqr = tmp_normal_in_b.length_squared();
+                let len_sqr = bullet_length_squared(tmp_normal_in_b);
                 if len_sqr > f32::EPSILON * f32::EPSILON {
                     let length = len_sqr.sqrt();
                     let distance_2 = -length;
@@ -110,18 +127,26 @@ impl GjkPairDetector {
                 if !is_valid || distance_2 < distance {
                     distance = distance_2;
                     point_on_b = tmp_point_on_b + result.normal * self.margin_b;
-                    normal_in_b = result.normal.normalize();
+                    normal_in_b = bullet_normalize(result.normal);
                     is_valid = true;
                 }
             }
         }
 
-        if is_valid && distance * distance < input.maximum_distance_squared {
+        // Bullet always reports penetrating contacts, even when their depth is
+        // beyond the positive closest-point threshold. The threshold only
+        // filters separated points; applying it to negative distances drops
+        // deep mesh contacts and changes the solver's impulse set.
+        let mut emitted = false;
+        if is_valid && (distance < 0.0 || distance * distance < input.maximum_distance_squared) {
             self.separating_axis = normal_in_b;
             self.separating_distance = distance;
 
             output.add_contact_point(normal_in_b, point_on_b + position_offset, distance);
+            emitted = true;
         }
+
+        (self.separating_axis, self.separating_distance, emitted)
     }
 
     fn compute_simplex_contact(
@@ -141,7 +166,7 @@ impl GjkPairDetector {
         result.normal_in_b = self.separating_axis;
 
         // valid normal
-        let len_sqr = self.separating_axis.length_squared();
+        let len_sqr = bullet_length_squared(self.separating_axis);
         if len_sqr < 0.0001 {
             result.degenerate_simplex = 5;
         }
@@ -186,7 +211,7 @@ impl GjkPairDetector {
             let q_world = transform_b.transform_point3a(q_in_b);
 
             let w = p_world - q_world;
-            let delta = self.separating_axis.dot(w);
+            let delta = bullet_dot(self.separating_axis, w);
 
             // Potential exit: the shapes are separated far enough.
             if delta > 0.0 && delta * delta > squared_distance * maximum_distance_squared {
@@ -223,7 +248,7 @@ impl GjkPairDetector {
                 break;
             }
 
-            if new_cached_separating_axis.length_squared() < REL_ERROR2 {
+            if bullet_length_squared(new_cached_separating_axis) < REL_ERROR2 {
                 self.separating_axis = new_cached_separating_axis;
                 degenerate_simplex = 6;
                 check_simplex = true;
@@ -231,7 +256,7 @@ impl GjkPairDetector {
             }
 
             let previous_squared_distance = squared_distance;
-            squared_distance = new_cached_separating_axis.length_squared();
+            squared_distance = bullet_length_squared(new_cached_separating_axis);
 
             // Are we getting any closer?
             if previous_squared_distance - squared_distance

--- a/rocketsim/src/bullet/collision/narrowphase/gjk/penetration.rs
+++ b/rocketsim/src/bullet/collision/narrowphase/gjk/penetration.rs
@@ -19,25 +19,51 @@ fn penetration(
     let shape = MinkowskiDiff::new(shape_a, *trans_a, shape_b, *trans_b);
 
     let mut gjk = Gjk::new(&shape);
-    match gjk.evaluate::<true>(-guess) {
+    let gjk_status = gjk.evaluate::<true>(-guess);
+    if std::env::var_os("RSIM_PEN_TRACE").is_some() {
+        let status_name = match gjk_status {
+            GjkStatus::Failed => "failed",
+            GjkStatus::Valid => "valid",
+            GjkStatus::Inside => "inside",
+        };
+        println!(
+            "rust_pen_gjk,guess={:?},status={},rank={}",
+            guess,
+            status_name,
+            gjk.simplex().rank
+        );
+    }
+    match gjk_status {
         GjkStatus::Failed | GjkStatus::Valid => return None,
         GjkStatus::Inside => {}
     }
 
     let mut epa = Epa2::new();
-    let status: EpaStatus = epa.evaluate::<true>(gjk, guess);
+    // Bullet's btGjkEpaSolver2 passes the negated initial guess to EPA after
+    // GJK was evaluated with -guess.  Keeping the sign here is important for
+    // the low-rank/degenerate fallback normal and for deterministic witnesses.
+    let status: EpaStatus = epa.evaluate::<true>(gjk, -guess);
+    if std::env::var_os("RSIM_PEN_TRACE").is_some() {
+        println!(
+            "rust_pen_epa,guess={:?},status={:?},rank={},depth={},normal={:?}",
+            guess, status, epa.result.rank, epa.depth, epa.normal
+        );
+    }
     debug_assert!(status == EpaStatus::Valid || status == EpaStatus::AccuracyReached);
 
     let mut w0 = Vec3A::ZERO;
     for i in 0..epa.result.rank {
-        w0 += shape.support0::<true>(epa.sv_store[epa.result.c[i]].d) * epa.result.p[i];
+        let direction = epa.sv_store[epa.result.c[i]].d;
+        let weight = epa.result.p[i];
+        w0 += shape.support0::<true>(direction) * weight;
     }
+    // Bullet's btGjkEpaSolver2 does not barycentrically reconstruct witness B
+    // here.  It derives it from the EPA normal/depth, which preserves the
+    // exact contact direction even when support vertices are duplicated.
+    let w1 = w0 - epa.normal * epa.depth;
 
     Some(GjkEpa2Result {
-        witnesses: [
-            trans_a.transform_point3a(w0),
-            trans_a.transform_point3a(w0 - epa.normal * epa.depth),
-        ],
+        witnesses: [trans_a.transform_point3a(w0), trans_a.transform_point3a(w1)],
         normal: -epa.normal,
         penetrating: true,
     })
@@ -75,7 +101,7 @@ fn distance(
     }
 
     Some(GjkEpa2Result {
-        witnesses: [w0, w1],
+        witnesses: [trans_a.transform_point3a(w0), trans_a.transform_point3a(w1)],
         normal: (w1 - w0).normalize_or_zero(),
         penetrating: false,
     })

--- a/rocketsim/src/bullet/collision/narrowphase/gjk/solver/epa2.rs
+++ b/rocketsim/src/bullet/collision/narrowphase/gjk/solver/epa2.rs
@@ -424,7 +424,10 @@ impl Epa2 {
         let mut best = self.find_best();
         let mut outer = self.fc_store[best];
 
-        'epa_iter: for pass in 0..Self::MAX_ITERATIONS {
+        // Bullet starts its pass counter at one. Faces are initialized with
+        // pass zero, so starting at zero would make the first expansion treat
+        // every adjacent face as already visited and abort the horizon walk.
+        'epa_iter: for pass in 1..=Self::MAX_ITERATIONS {
             if self.next_sv >= Self::MAX_VERTICES {
                 status = EpaStatus::OutOfVertices;
                 break;

--- a/rocketsim/src/bullet/collision/narrowphase/gjk/solver/gjk.rs
+++ b/rocketsim/src/bullet/collision/narrowphase/gjk/solver/gjk.rs
@@ -95,6 +95,7 @@ impl<'a> Gjk<'a> {
     }
 
     pub fn evaluate<const ENABLE_MARGIN: bool>(&mut self, guess: Vec3A) -> GjkStatus {
+        let trace_detail = std::env::var_os("RSIM_GJK_DETAIL").is_some();
         let mut status = GjkStatus::Valid;
         let mut iterations = 0usize;
         let mut alpha = 0.0f32;
@@ -109,6 +110,18 @@ impl<'a> Gjk<'a> {
         self.simplices[0].p[0] = 1.0;
         let first_index = self.simplices[0].c[0];
         self.ray = self.store[first_index].w;
+        if trace_detail {
+            let d = self.store[first_index].d;
+            println!(
+                "rust_gjk_begin,guess={:?},margin={},d={:?},p={:?},q={:?},w={:?}",
+                guess,
+                ENABLE_MARGIN as u8,
+                d,
+                self.shape.support0::<ENABLE_MARGIN>(d),
+                self.shape.support1::<ENABLE_MARGIN>(-d),
+                self.store[first_index].w
+            );
+        }
 
         let mut lastw = [self.ray; 4];
 
@@ -125,6 +138,18 @@ impl<'a> Gjk<'a> {
             self.append_vertex::<ENABLE_MARGIN>(current, -self.ray);
             let cs = self.simplices[current];
             let w = self.store[cs.c[cs.rank - 1]].w;
+            if trace_detail && iterations < 16 {
+                let d = self.store[cs.c[cs.rank - 1]].d;
+                println!(
+                    "rust_gjk_support,iter={},d={:?},p={:?},q={:?},w={:?},rank={}",
+                    iterations,
+                    d,
+                    self.shape.support0::<ENABLE_MARGIN>(d),
+                    self.shape.support1::<ENABLE_MARGIN>(-d),
+                    w,
+                    cs.rank
+                );
+            }
 
             let mut found = false;
             for lastw in lastw {

--- a/rocketsim/src/bullet/collision/narrowphase/gjk/solver/minkowski_diff.rs
+++ b/rocketsim/src/bullet/collision/narrowphase/gjk/solver/minkowski_diff.rs
@@ -1,18 +1,21 @@
 use glam::{Affine3A, Vec3A};
 
-use crate::bullet::collision::shapes::collision_shape::CollisionShapes;
+use crate::bullet::{collision::shapes::collision_shape::CollisionShapes, linear_math::AffineExt};
 
 /// Minkowski support wrapper for GJK/EPA.
 /// Computes support points in world space for two convex shapes.
 pub struct MinkowskiDiff<'a> {
     pub shape_a: &'a CollisionShapes,
     pub shape_b: &'a CollisionShapes,
+    /// Transform from shape-B local coordinates into shape-A local space.
+    /// Bullet's btGjkEpaSolver2 performs its EPA in this relative frame,
+    /// avoiding large world-space translations and preserving its float path.
+    pub b_to_a: Affine3A,
     pub trans_a: Affine3A,
-    pub trans_b: Affine3A,
 }
 
 impl<'a> MinkowskiDiff<'a> {
-    pub const fn new(
+    pub fn new(
         shape_a: &'a CollisionShapes,
         trans_a: Affine3A,
         shape_b: &'a CollisionShapes,
@@ -21,33 +24,27 @@ impl<'a> MinkowskiDiff<'a> {
         Self {
             shape_a,
             shape_b,
+            b_to_a: trans_a.transpose() * trans_b,
             trans_a,
-            trans_b,
         }
     }
 
-    pub fn support0<const ENABLE_MAGIN: bool>(&self, dir_world: Vec3A) -> Vec3A {
-        let dir_local = self.trans_a.matrix3.mul_transpose_vec3a(dir_world);
-        let local_support = if ENABLE_MAGIN {
-            self.shape_a.local_get_supporting_vertex(dir_local)
+    pub fn support0<const ENABLE_MAGIN: bool>(&self, dir_a: Vec3A) -> Vec3A {
+        if ENABLE_MAGIN {
+            self.shape_a.local_get_supporting_vertex(dir_a)
         } else {
-            self.shape_a
-                .local_get_support_vertex_without_margin(dir_local)
-        };
-
-        self.trans_a.transform_point3a(local_support)
+            self.shape_a.local_get_support_vertex_without_margin(dir_a)
+        }
     }
 
-    pub fn support1<const ENABLE_MAGIN: bool>(&self, dir_world: Vec3A) -> Vec3A {
-        let dir_local = self.trans_b.matrix3.mul_transpose_vec3a(dir_world);
+    pub fn support1<const ENABLE_MAGIN: bool>(&self, dir_a: Vec3A) -> Vec3A {
+        let dir_b = self.b_to_a.matrix3.transpose() * dir_a;
         let local_support = if ENABLE_MAGIN {
-            self.shape_b.local_get_supporting_vertex(dir_local)
+            self.shape_b.local_get_supporting_vertex(dir_b)
         } else {
-            self.shape_b
-                .local_get_support_vertex_without_margin(dir_local)
+            self.shape_b.local_get_support_vertex_without_margin(dir_b)
         };
-
-        self.trans_b.transform_point3a(local_support)
+        self.b_to_a.transform_point3a(local_support)
     }
 
     /// Minkowski support point for the difference A - B.

--- a/rocketsim/src/bullet/collision/shapes/bvh_triangle_mesh_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/bvh_triangle_mesh_shape.rs
@@ -47,6 +47,19 @@ impl BvhTriangleMeshShape {
     }
 
     pub fn process_all_triangles<T: ProcessTriangle>(&self, callback: &mut T, aabb: &Aabb) {
+        // Diagnostic mode: force the same stable triangle-index order for all
+        // overlapping leaves.  The normal path retains the fast BVH callback
+        // traversal; this switch lets parity tests isolate ordering effects.
+        if std::env::var_os("RSIM_SORT_TRIANGLES").is_some() && callback.stable_triangle_order() {
+            let mut indices = self.bvh.collect_aabb_overlapping_indices(aabb);
+            indices.sort_unstable();
+            let tris = self.get_mesh_interface().get_tris();
+            for idx in indices {
+                callback.process_triangle(&tris[idx], idx);
+            }
+            return;
+        }
+
         let mut my_node_callback = NodeOverlapCallback::new(self.get_mesh_interface(), callback);
         self.bvh
             .report_aabb_overlapping_node(&mut my_node_callback, aabb);

--- a/rocketsim/src/bullet/collision/shapes/compound_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/compound_shape.rs
@@ -1,6 +1,8 @@
 use glam::{Affine3A, Vec3A};
 
-use super::box_shape::BoxShape;
+use super::{
+    box_shape::BoxShape, collision_shape::CollisionShapes, convex_hull_shape::ConvexHullShape,
+};
 use crate::{
     bullet::collision::dispatch::quad_ray_callbacks::{
         BridgeTriQuadRayCallback, QuadRayResultCallback,
@@ -11,16 +13,25 @@ use crate::{
 pub struct CompoundShape {
     pub child_shape: BoxShape,
     pub child_trans: Affine3A,
+    /// Convex proxy for the child box, cached for mesh GJK narrowphase calls.
+    pub gjk_shape: Box<CollisionShapes>,
     local_aabb: Aabb,
 }
 
 impl CompoundShape {
     pub fn new(child_shape: BoxShape, child_trans: Affine3A) -> Self {
         let local_aabb = child_shape.get_aabb(&child_trans);
-
+        let collision_margin = child_shape.get_margin();
+        let half_extents = child_shape.get_half_extents();
+        // Keep the cached proxy's vertices margin-free, matching Bullet's
+        // btBoxShape::localGetSupportVertexWithoutMargin path. The analytical
+        // box margin is supplied by the GJK detector below.
         Self {
             child_shape,
             child_trans,
+            gjk_shape: Box::new(CollisionShapes::ConvexHull(
+                ConvexHullShape::new_box_with_margin(half_extents, collision_margin),
+            )),
             local_aabb,
         }
     }

--- a/rocketsim/src/bullet/collision/shapes/convex_hull_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/convex_hull_shape.rs
@@ -6,6 +6,7 @@ use crate::{
         collision::{
             dispatch::quad_ray_callbacks::{BridgeTriQuadRayCallback, QuadRayResultCallback},
             narrowphase::gjk::calc_time_of_impact,
+            shapes::collision_margin::CONVEX_DISTANCE_MARGIN,
         },
         linear_math::max_dot,
     },
@@ -16,10 +17,19 @@ pub struct ConvexHullShape {
     polyhedral_convex_shape: PolyhedralConvexShape,
     unscaled_points: Box<[Vec3A]>,
     simd_unscaled_points: Box<[[Vec4; 3]]>,
+    /// When true this eight-point hull is a btBoxShape proxy. Bullet's box
+    /// support uses per-component sign selection (including + for zero), while
+    /// the generic Bullet margin path expands the corner along the normalized
+    /// query direction.
+    box_support: bool,
 }
 
 impl ConvexHullShape {
     pub fn new(unscaled_points: Box<[Vec3A]>) -> Self {
+        Self::new_with_margin(unscaled_points, CONVEX_DISTANCE_MARGIN)
+    }
+
+    pub fn new_with_margin(unscaled_points: Box<[Vec3A]>, collision_margin: f32) -> Self {
         let simd_unscaled_points: Box<_> = unscaled_points
             .as_chunks::<4>()
             .0
@@ -34,21 +44,68 @@ impl ConvexHullShape {
             .collect();
 
         Self {
-            polyhedral_convex_shape: PolyhedralConvexShape::new(
+            polyhedral_convex_shape: PolyhedralConvexShape::new_with_margin(
                 &simd_unscaled_points,
                 &unscaled_points,
+                collision_margin,
             ),
             unscaled_points,
             simd_unscaled_points,
+            box_support: false,
         }
+    }
+
+    pub fn new_box_with_margin(half_extents: Vec3A, collision_margin: f32) -> Self {
+        let points = [
+            Vec3A::new(-half_extents.x, -half_extents.y, -half_extents.z),
+            Vec3A::new(half_extents.x, -half_extents.y, -half_extents.z),
+            Vec3A::new(-half_extents.x, half_extents.y, -half_extents.z),
+            Vec3A::new(half_extents.x, half_extents.y, -half_extents.z),
+            Vec3A::new(-half_extents.x, -half_extents.y, half_extents.z),
+            Vec3A::new(half_extents.x, -half_extents.y, half_extents.z),
+            Vec3A::new(-half_extents.x, half_extents.y, half_extents.z),
+            Vec3A::new(half_extents.x, half_extents.y, half_extents.z),
+        ];
+        let mut shape = Self::new_with_margin(points.into(), collision_margin);
+        shape.box_support = true;
+        shape
     }
 
     #[inline]
     pub fn local_get_supporting_vertex_without_margin(&self, vec: Vec3A) -> Vec3A {
+        if self.box_support {
+            let h =
+                self.polyhedral_convex_shape.get_ident_aabb().max - Vec3A::splat(self.get_margin());
+            return Vec3A::new(
+                if vec.x >= 0.0 { h.x } else { -h.x },
+                if vec.y >= 0.0 { h.y } else { -h.y },
+                if vec.z >= 0.0 { h.z } else { -h.z },
+            );
+        }
         max_dot(&self.simd_unscaled_points, &self.unscaled_points, vec)
     }
 
     pub fn local_get_supporting_vertex(&self, vec: Vec3A) -> Vec3A {
+        if self.box_support {
+            // btConvexShape::localGetSupportVertexNonVirtual (used by
+            // btGjkEpa2 with margins) selects the margin-free box corner,
+            // then expands it by margin along the normalized query vector.
+            // It does not use btBoxShape::localGetSupportingVertex's
+            // component-wise full-extents corner.
+            let h =
+                self.polyhedral_convex_shape.get_ident_aabb().max - Vec3A::splat(self.get_margin());
+            let vec_norm = if vec.length_squared() < f32::EPSILON * f32::EPSILON {
+                crate::bullet::linear_math::bullet_normalize(Vec3A::NEG_ONE)
+            } else {
+                crate::bullet::linear_math::bullet_normalize(vec)
+            };
+            let corner = Vec3A::new(
+                if vec_norm.x >= 0.0 { h.x } else { -h.x },
+                if vec_norm.y >= 0.0 { h.y } else { -h.y },
+                if vec_norm.z >= 0.0 { h.z } else { -h.z },
+            );
+            return corner + self.get_margin() * vec_norm;
+        }
         let mut sup_vertex = self.local_get_supporting_vertex_without_margin(vec);
 
         debug_assert_ne!(self.polyhedral_convex_shape.get_margin(), 0.0);

--- a/rocketsim/src/bullet/collision/shapes/optimized_bvh.rs
+++ b/rocketsim/src/bullet/collision/shapes/optimized_bvh.rs
@@ -48,5 +48,13 @@ pub fn create_bvh(triangles: &TriangleMesh, aabb: Aabb) -> Tree {
         })
         .collect();
 
-    Tree::build(aabb, &mut leaf_nodes)
+    // RocketSim V2 uses Bullet's btQuantizedBvh for arena meshes.  Use the
+    // matching variance/mean split order by default so manifold contact order
+    // (and therefore sequential-impulse results) stays comparable.  The
+    // previous SAH builder remains available for A/B diagnostics.
+    if std::env::var_os("RSIM_SAH_BVH").is_some() {
+        Tree::build(aabb, &mut leaf_nodes)
+    } else {
+        Tree::build_bullet(aabb, &mut leaf_nodes)
+    }
 }

--- a/rocketsim/src/bullet/collision/shapes/polyhedral_convex_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/polyhedral_convex_shape.rs
@@ -41,8 +41,19 @@ pub struct PolyhedralConvexShape {
 
 impl PolyhedralConvexShape {
     pub fn new(simd_points: &[[Vec4; 3]], points: &[Vec3A]) -> Self {
-        let convex_internal_shape = ConvexInternalShape::default();
-        let local_aabb = calc_local_aabb(simd_points, points, convex_internal_shape.margin);
+        Self::new_with_margin(simd_points, points, ConvexInternalShape::default().margin)
+    }
+
+    pub fn new_with_margin(
+        simd_points: &[[Vec4; 3]],
+        points: &[Vec3A],
+        collision_margin: f32,
+    ) -> Self {
+        let convex_internal_shape = ConvexInternalShape {
+            implicit_dim: Vec3A::ZERO,
+            margin: collision_margin,
+        };
+        let local_aabb = calc_local_aabb(simd_points, points, collision_margin);
 
         Self {
             convex_internal_shape,

--- a/rocketsim/src/bullet/collision/shapes/static_plane_shape.rs
+++ b/rocketsim/src/bullet/collision/shapes/static_plane_shape.rs
@@ -1,9 +1,13 @@
-use glam::{Affine3A, Vec3A, Vec4};
+use glam::{Affine3A, Vec3A};
 
 use crate::{
     bullet::collision::dispatch::quad_ray_callbacks::{
         BridgeTriQuadRayCallback, QuadRayResultCallback,
     },
+    bullet::collision::shapes::{
+        triangle_callback::ProcessQuadRayTriangle, triangle_shape::TriangleShape,
+    },
+    bullet::linear_math::bullet_normalize,
     shared::{Aabb, QuadRayInfo},
 };
 
@@ -20,6 +24,7 @@ pub struct StaticPlaneShape {
 
 impl StaticPlaneShape {
     pub fn new(world_trans: Affine3A, plane_normal: Vec3A) -> Self {
+        let plane_normal = bullet_normalize(plane_normal);
         debug_assert!(plane_normal.is_normalized());
 
         let [x, y, z]: [bool; 3] = plane_normal.abs().cmpge(Vec3A::splat(f32::EPSILON)).into();
@@ -88,68 +93,64 @@ impl StaticPlaneShape {
             return;
         }
 
-        let sources = ray_info.ray_sources;
-        let targets = ray_info.ray_targets;
+        // btStaticPlaneShape::processAllTriangles generates two finite
+        // triangles covering the query AABB, then routes them through
+        // btTriangleRaycastCallback. Reproduce that sequence instead of
+        // intersecting the infinite plane directly; the arithmetic affects
+        // the final hit point by a few ulps and feeds wheel friction.
+        let mut lambda_max = result_callback.hit_fraction;
 
-        let source_x = Vec4::new(sources[0].x, sources[1].x, sources[2].x, sources[3].x);
-        let source_y = Vec4::new(sources[0].y, sources[1].y, sources[2].y, sources[3].y);
-        let source_z = Vec4::new(sources[0].z, sources[1].z, sources[2].z, sources[3].z);
+        // The C++ vehicle raycaster submits each wheel ray independently, so
+        // btStaticPlaneShape receives that single segment's AABB. Build the
+        // two covering triangles per lane rather than using the union AABB of
+        // the packet (which would change the generated radius).
+        for i in 0..4 {
+            let ray_min = ray_info.ray_sources[i].min(ray_info.ray_targets[i]);
+            let ray_max = ray_info.ray_sources[i].max(ray_info.ray_targets[i]);
+            let half_extents = 0.5 * (ray_max - ray_min);
+            let radius = half_extents.length();
+            let center = 0.5 * (ray_max + ray_min);
 
-        let target_x = Vec4::new(targets[0].x, targets[1].x, targets[2].x, targets[3].x);
-        let target_y = Vec4::new(targets[0].y, targets[1].y, targets[2].y, targets[3].y);
-        let target_z = Vec4::new(targets[0].z, targets[1].z, targets[2].z, targets[3].z);
+            let projected_center = center - self.plane_normal.dot(center) * self.plane_normal;
+            let (tangent_0, tangent_1) = if self.plane_normal.z.abs() > 0.7071067811865475 {
+                let a = self.plane_normal.y * self.plane_normal.y
+                    + self.plane_normal.z * self.plane_normal.z;
+                let k = a.sqrt().recip();
+                let p = Vec3A::new(0.0, -self.plane_normal.z * k, self.plane_normal.y * k);
+                let q = Vec3A::new(a * k, -self.plane_normal.x * p.z, self.plane_normal.x * p.y);
+                (p, q)
+            } else {
+                let a = self.plane_normal.x * self.plane_normal.x
+                    + self.plane_normal.y * self.plane_normal.y;
+                let k = a.sqrt().recip();
+                let p = Vec3A::new(-self.plane_normal.y * k, self.plane_normal.x * k, 0.0);
+                let q = Vec3A::new(-self.plane_normal.z * p.y, self.plane_normal.z * p.x, a * k);
+                (p, q)
+            };
 
-        let delta_x = target_x - source_x;
-        let delta_y = target_y - source_y;
-        let delta_z = target_z - source_z;
+            let triangles = [
+                [
+                    projected_center + tangent_0 * radius + tangent_1 * radius,
+                    projected_center + tangent_0 * radius - tangent_1 * radius,
+                    projected_center - tangent_0 * radius - tangent_1 * radius,
+                ],
+                [
+                    projected_center - tangent_0 * radius - tangent_1 * radius,
+                    projected_center - tangent_0 * radius + tangent_1 * radius,
+                    projected_center + tangent_0 * radius + tangent_1 * radius,
+                ],
+            ];
 
-        let inv_delta_x = Vec4::ONE / delta_x;
-        let inv_delta_y = Vec4::ONE / delta_y;
-        let inv_delta_z = Vec4::ONE / delta_z;
-
-        let ray_mask = QuadRayInfo::intersect_quad_ray_aabb(
-            &[source_x, source_y, source_z],
-            &[inv_delta_x, inv_delta_y, inv_delta_z],
-            plane,
-            result_callback.hit_fraction,
-        );
-        if ray_mask == 0 {
-            return;
-        }
-
-        let dist = (delta_x * delta_x + delta_y * delta_y + delta_z * delta_z).sqrt();
-        let inv_dist = Vec4::ONE / dist;
-
-        let dir_x = delta_x * inv_dist;
-        let dir_y = delta_y * inv_dist;
-        let dir_z = delta_z * inv_dist;
-
-        let dir_align =
-            dir_x * self.plane_normal.x + dir_y * self.plane_normal.y + dir_z * self.plane_normal.z;
-        let dir_align_mask = dir_align.abs().cmpge(Vec4::splat(f32::EPSILON));
-        if !dir_align_mask.any() {
-            return;
-        }
-
-        let normal_start = source_x * self.plane_normal.x
-            + source_y * self.plane_normal.y
-            + source_z * self.plane_normal.z;
-
-        let t = -normal_start / dir_align;
-
-        let t_mask = t.cmpge(Vec4::ZERO) & t.cmplt(dist);
-        let hit_mask = ray_mask & (dir_align_mask & t_mask).bitmask() as u8;
-        if hit_mask == 0 {
-            return;
-        }
-
-        let hit_fraction = t / dist;
-        for (i, hit_fraction) in hit_fraction.to_array().into_iter().enumerate() {
-            if (hit_mask & (1 << i)) == 0 {
-                continue;
+            for points in triangles {
+                // process_triangle recomputes Bullet's unnormalized normal;
+                // avoid the unused cached-normal normalization here.
+                let triangle = TriangleShape {
+                    points,
+                    normal: Vec3A::ZERO,
+                    normal_length: 0.0,
+                };
+                result_callback.process_node(&triangle, 1 << i, &mut lambda_max);
             }
-
-            result_callback.report_hit(self.plane_normal, hit_fraction, i);
         }
     }
 }

--- a/rocketsim/src/bullet/collision/shapes/triangle_callback.rs
+++ b/rocketsim/src/bullet/collision/shapes/triangle_callback.rs
@@ -4,6 +4,13 @@ use super::triangle_shape::TriangleShape;
 
 pub trait ProcessTriangle {
     fn process_triangle(&mut self, triangle: &TriangleShape, triangle_idx: usize);
+
+    /// Diagnostic hook used by parity benchmarks to isolate callback-order
+    /// effects.  Compound-car callbacks may opt into stable triangle-index
+    /// ordering without changing sphere/mesh traversal.
+    fn stable_triangle_order(&self) -> bool {
+        false
+    }
 }
 
 pub trait ProcessQuadRayTriangle {

--- a/rocketsim/src/bullet/dynamics/constraint_solver/contact_constraint.rs
+++ b/rocketsim/src/bullet/dynamics/constraint_solver/contact_constraint.rs
@@ -31,8 +31,7 @@ pub fn resolve_single_collision(
     let penetration_impulse = positional_error * jac_diag_ab_inv;
     let vel_impulse = vel_error * jac_diag_ab_inv;
 
-    let normal_impulse = penetration_impulse + vel_impulse;
-    normal_impulse.max(0.0)
+    (penetration_impulse + vel_impulse).max(0.0)
 }
 
 pub fn resolve_single_bilateral(

--- a/rocketsim/src/bullet/dynamics/constraint_solver/contact_solver_info.rs
+++ b/rocketsim/src/bullet/dynamics/constraint_solver/contact_solver_info.rs
@@ -1,8 +1,12 @@
 pub const NUM_ITERATIONS: usize = 10;
 pub const SOR: f32 = 1.0;
-pub const WHEEL_PUSHBACK_ERP: f32 = 0.1;
+// Bullet's btContactSolverInfo uses m_erp = 0.2 for wheel raycast pushback.
+pub const WHEEL_PUSHBACK_ERP: f32 = 0.2;
+// RocketSim v2 overrides Bullet's contact ERP for legacy behavior.
 pub const ERP_2: f32 = 0.8;
+// RocketSim v2 also overrides the split-impulse threshold, causing all
+// contacts to use the split-penetration path.
 pub const SPLIT_IMPULSE_PENETRATION_THRESHOLD: f32 = 1e30;
 pub const SPLIT_IMPULSE_TURN_ERP: f32 = 0.1;
 pub const WARMSTARTING_FACTOR: f32 = 0.85;
-pub const RESTITUTION_VELOCITY_THRESHOLD: f32 = 1.0;
+pub const RESTITUTION_VELOCITY_THRESHOLD: f32 = 0.2;

--- a/rocketsim/src/bullet/dynamics/constraint_solver/seq_impulse_constraint_solver.rs
+++ b/rocketsim/src/bullet/dynamics/constraint_solver/seq_impulse_constraint_solver.rs
@@ -146,17 +146,20 @@ impl SeqImpulseConstraintSolver {
                 let rel_pos1 = cp.pos_world_on_a - body0.get_world_trans().translation;
                 let rel_pos2 = cp.pos_world_on_b - body1.get_world_trans().translation;
 
-                if cp.is_special {
-                    self.special_resolve_info
-                        .add_special_collision(body0, body1, cp, rel_pos1, rel_pos2);
-
-                    // Skip normal contact processing for special contacts
-                    continue;
-                }
-
                 let rb0 = solver_body_a.original_body.map(|_| &*body0);
                 let rb1 = solver_body_b.original_body.map(|_| &*body1);
                 let friction_idx = self.tmp_solver_contact_friction_constraint_pool.len();
+
+                // V2 retains the original special manifold in the contact pool.
+                // Its split-impulse pass therefore applies the manifold's
+                // penetration correction, while the regular velocity pass
+                // skips it via SolverConstraint::is_special.  The aggregated
+                // special constraint below supplies the ball/world velocity
+                // response.  Do not discard the manifold before split impulse.
+                if cp.is_special {
+                    self.special_resolve_info
+                        .add_special_collision(body0, body1, cp, rel_pos1, rel_pos2);
+                }
 
                 self.tmp_solver_contact_constraint_pool.push(
                     SolverConstraint::get_contact_constraint(
@@ -233,6 +236,23 @@ impl SeqImpulseConstraintSolver {
         let distance = sri.total_dist / num_collisions;
         let normal_world_on_b = (sri.total_normal / num_collisions).normalize_or_zero();
 
+        if std::env::var("RSIM_DEBUG_SPECIAL").is_ok() {
+            println!(
+                "rust_special,num={},total_normal={:?},total_dist={},avg_normal={:?},avg_dist={},friction={},restitution={},body={},pos={:?},lin={:?},ang={:?}",
+                sri.num_special_collisions,
+                sri.total_normal,
+                sri.total_dist,
+                normal_world_on_b,
+                distance,
+                sri.friction,
+                sri.restitution,
+                body.world_array_idx,
+                body.get_world_trans().translation,
+                body.lin_vel,
+                body.ang_vel,
+            );
+        }
+
         let friction_idx = self.tmp_solver_contact_constraint_pool.len();
 
         let solver_body_id_a = body.companion_id.unwrap();
@@ -299,6 +319,43 @@ impl SeqImpulseConstraintSolver {
             } else {
                 (vel_impulse, penetration_impulse)
             };
+
+        // Temporary diagnostic for the one remaining full-replay divergence.  The
+        // coordinate gate keeps this focused on the ball near the floor contact
+        // around transition 2130; remove with the other debug instrumentation once
+        // the solver parity fix is identified.
+        let p = body.get_world_trans().translation;
+        if std::env::var("RSIM_DEBUG_SPECIAL_DETAIL").is_ok()
+            && p.x > -11.0
+            && p.x < -9.0
+            && p.y > 79.0
+            && p.y < 81.0
+            && p.z < 3.0
+        {
+            println!(
+                "rust_special_detail,body={},pos={:?},distance={},normal={:?},rel_pos={:?},body_lin={:?},body_ang={:?},solver_lin={:?},solver_ang={:?},ext_lin={:?},ext_ang={:?},rel_vel_pre={},restitution={},jac={},penetration={},pos_error={},vel_error={},rhs={},rhs_pen={},applied={}",
+                body.world_array_idx,
+                p,
+                distance,
+                normal_world_on_b,
+                rel_pos1,
+                body.lin_vel,
+                body.ang_vel,
+                solver_body_a.lin_vel,
+                solver_body_a.ang_vel,
+                external_force_impulse_a,
+                external_torque_impulse_a,
+                rel_vel,
+                restitution,
+                jac_diag_ab_inv,
+                penetration,
+                positional_error,
+                vel_error,
+                rhs,
+                rhs_penetration,
+                0.0f32,
+            );
+        }
 
         self.tmp_solver_contact_constraint_pool
             .push(SolverConstraint {
@@ -406,7 +463,11 @@ impl SeqImpulseConstraintSolver {
     fn solve_single_iteration(&mut self) -> f32 {
         let mut least_squares_residual = 0.0;
 
-        for contact in &mut self.tmp_solver_contact_constraint_pool {
+        for (contact_idx, contact) in self
+            .tmp_solver_contact_constraint_pool
+            .iter_mut()
+            .enumerate()
+        {
             if contact.is_special {
                 continue;
             }
@@ -419,7 +480,43 @@ impl SeqImpulseConstraintSolver {
                 ])
             };
 
+            let detail = std::env::var("RSIM_DEBUG_SPECIAL_DETAIL").is_ok()
+                && (body_a.original_body == Some(20) || body_b.original_body == Some(20))
+                && body_a.world_trans.translation.x > -11.0
+                && body_a.world_trans.translation.x < -9.0
+                && body_a.world_trans.translation.y > 79.0
+                && body_a.world_trans.translation.y < 81.0
+                && body_a.world_trans.translation.z < 3.0;
+            if detail {
+                println!(
+                    "rust_constraint_before,idx={},special={},a={},b={},rhs={},rhs_pen={},jac={},applied={},lower={},upper={},normal={:?},delta_lin_a={:?},delta_ang_a={:?}",
+                    contact_idx,
+                    contact.is_special,
+                    contact.solver_body_id_a,
+                    contact.solver_body_id_b,
+                    contact.rhs,
+                    contact.rhs_penetration,
+                    contact.jac_diag_ab_inv,
+                    contact.applied_impulse,
+                    contact.lower_limit,
+                    contact.upper_limit,
+                    contact.contact_normal_1,
+                    body_a.delta_lin_vel,
+                    body_a.delta_ang_vel,
+                );
+            }
+
             let residual = contact.resolve_single_constraint_row_lower_limit(body_a, body_b);
+            if detail {
+                println!(
+                    "rust_constraint_after,idx={},residual={},applied={},delta_lin_a={:?},delta_ang_a={:?}",
+                    contact_idx,
+                    residual,
+                    contact.applied_impulse,
+                    body_a.delta_lin_vel,
+                    body_a.delta_ang_vel,
+                );
+            }
             least_squares_residual = (residual * residual).max(least_squares_residual);
         }
 
@@ -466,6 +563,24 @@ impl SeqImpulseConstraintSolver {
             let Some(body) = solver.original_body.map(|idx| &mut collision_objs[idx]) else {
                 continue;
             };
+
+            if std::env::var("RSIM_SOLVER_DEBUG").is_ok()
+                && body.world_array_idx == 20
+                && solver.push_vel.length_squared() > 0.0
+            {
+                println!(
+                    "rust_solver_body,idx={},pre_pos={:?},pre_lin={:?},pre_ang={:?},delta_lin={:?},delta_ang={:?},push={:?},turn={:?},inv_mass={:?}",
+                    body.world_array_idx,
+                    body.get_world_trans().translation,
+                    body.lin_vel,
+                    body.ang_vel,
+                    solver.delta_lin_vel,
+                    solver.delta_ang_vel,
+                    solver.push_vel,
+                    solver.turn_vel,
+                    solver.inv_mass,
+                );
+            }
 
             solver.lin_vel += solver.delta_lin_vel;
             solver.ang_vel += solver.delta_ang_vel;

--- a/rocketsim/src/bullet/dynamics/discrete_dynamics_world.rs
+++ b/rocketsim/src/bullet/dynamics/discrete_dynamics_world.rs
@@ -136,6 +136,30 @@ impl DiscreteDynamicsWorld {
         );
     }
 
+    /// Match Bullet's simulation-island activation pass: a sleeping dynamic
+    /// body is made active when it shares a contact manifold with an awake
+    /// dynamic body, so the post-solver transform integration runs this tick.
+    fn wake_contacting_bodies(&mut self) {
+        let mut wake = Vec::new();
+        for manifold in &self.collision_world.dispatcher1.manifolds {
+            let a = manifold.body0_idx;
+            let b = manifold.body1_idx;
+            let body_a = &self.collision_world.collision_objs[a];
+            let body_b = &self.collision_world.collision_objs[b];
+            if body_a.is_static_obj() || body_b.is_static_obj() {
+                continue;
+            }
+            if body_a.is_active() && !body_b.is_active() {
+                wake.push(b);
+            } else if body_b.is_active() && !body_a.is_active() {
+                wake.push(a);
+            }
+        }
+        for idx in wake {
+            self.collision_world.collision_objs[idx].force_activate();
+        }
+    }
+
     fn integrate_trans_internal(&mut self, time_step: f32) {
         for &body in &self.dynamic_body_idcs {
             let body = &mut self.collision_world.collision_objs[body];
@@ -179,6 +203,7 @@ impl DiscreteDynamicsWorld {
         self.collision_world
             .perform_discrete_collision_detection(contact_added_callback);
 
+        self.wake_contacting_bodies();
         self.solve_constraints(time_step);
         self.integrate_trans(time_step);
         self.update_activation_state(time_step);

--- a/rocketsim/src/bullet/dynamics/rigid_body.rs
+++ b/rocketsim/src/bullet/dynamics/rigid_body.rs
@@ -7,7 +7,9 @@ use indexmap::IndexMap;
 use crate::{
     bullet::{
         collision::shapes::collision_shape::CollisionShapes,
-        linear_math::{integrate_trans, integrate_trans_no_rot},
+        linear_math::{
+            bullet_normalize, bullet_quat_from_mat3, integrate_trans, integrate_trans_no_rot,
+        },
     },
     sim::UserInfoTypes,
 };
@@ -187,7 +189,7 @@ impl RigidBody {
 
         Self {
             world_trans: info.start_world_trans,
-            world_quat: Quat::from_mat3a(&info.start_world_trans.matrix3),
+            world_quat: bullet_quat_from_mat3(info.start_world_trans.matrix3),
             interp_world_trans: info.start_world_trans,
             contact_processing_threshold: f32::MAX,
             broadphase_handle: 0,
@@ -221,7 +223,7 @@ impl RigidBody {
 
     pub fn set_world_trans(&mut self, world_trans: Affine3A) {
         if (self.collision_flags & CollisionFlags::NoAngularMotion) == 0 {
-            self.world_quat = Quat::from_mat3a(&world_trans.matrix3);
+            self.world_quat = bullet_quat_from_mat3(world_trans.matrix3);
         }
 
         self.world_trans = world_trans;
@@ -321,7 +323,15 @@ impl RigidBody {
             }
             Impulse::LinearRelPos(v, rel_pos) => {
                 lin_impulse = v * massed_scaler;
-                ang_impulse = self.inv_inertia_tensor_world * rel_pos.cross(v);
+                // Mat3A stores the world inertia tensor in the transposed
+                // Bullet row/column convention used throughout the solver.
+                // `Mat3A` stores this tensor in column form, while the Bullet
+                // compatibility values are exposed in row form. The
+                // transpose-vector multiply is therefore the Bullet-equivalent
+                // world-inertia application here.
+                ang_impulse = self
+                    .inv_inertia_tensor_world
+                    .mul_transpose_vec3a(rel_pos.cross(v));
                 if !massed {
                     ang_impulse *= self.mass; // Have to undo the effects of inv inertia tensor
                 }
@@ -448,11 +458,11 @@ impl RigidBody {
 
     pub fn limit_vels(&mut self, max_lin_speed: f32, max_ang_speed: f32) {
         if self.lin_vel.length_squared() > max_lin_speed.powi(2) {
-            self.lin_vel = self.lin_vel.normalize_or_zero() * max_lin_speed;
+            self.lin_vel = bullet_normalize(self.lin_vel) * max_lin_speed;
         }
 
         if self.ang_vel.length_squared() > max_ang_speed.powi(2) {
-            self.ang_vel = self.ang_vel.normalize_or_zero() * max_ang_speed;
+            self.ang_vel = bullet_normalize(self.ang_vel) * max_ang_speed;
         }
     }
 }

--- a/rocketsim/src/bullet/dynamics/vehicle/raycaster.rs
+++ b/rocketsim/src/bullet/dynamics/vehicle/raycaster.rs
@@ -5,6 +5,7 @@ use crate::bullet::{
         ClosestQuadRayResultCallback, QuadRayResultCallback,
     },
     dynamics::{discrete_dynamics_world::DiscreteDynamicsWorld, rigid_body::RigidBody},
+    linear_math::bullet_normalize,
 };
 
 #[derive(Clone, Copy)]
@@ -45,7 +46,9 @@ impl VehicleRaycaster {
                     *result = Some(VehicleRaycasterResult {
                         rigid_body: rb,
                         hit_point_in_world: ray_callback.hit_point_world[i],
-                        hit_normal_in_world: ray_callback.hit_normal_world[i].normalize_or_zero(),
+                        // btDefaultVehicleRaycaster normalizes the callback
+                        // normal once more before handing it to the vehicle.
+                        hit_normal_in_world: bullet_normalize(ray_callback.hit_normal_world[i]),
                     });
                 }
             }

--- a/rocketsim/src/bullet/dynamics/vehicle/vehicle_rl.rs
+++ b/rocketsim/src/bullet/dynamics/vehicle/vehicle_rl.rs
@@ -1,10 +1,13 @@
 use glam::Vec3A;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{NUM_WHEELS, raycaster::VehicleRaycaster, wheel_info::WheelInfo};
 use crate::bullet::{
     collision::broadphase::CollisionFilterGroups,
     dynamics::{discrete_dynamics_world::DiscreteDynamicsWorld, rigid_body::RigidBody},
 };
+
+static FRIC_TRACE_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 pub struct VehicleRL {
     raycaster: VehicleRaycaster,
@@ -38,14 +41,11 @@ impl VehicleRL {
         self.wheels.len()
     }
 
-    pub fn update(
-        &mut self,
-        collision_world: &mut DiscreteDynamicsWorld,
-        time_step: f32,
-        handbrake_val: f32,
-        real_throttle: f32,
-        three_wheels: bool,
-    ) {
+    /// Perform the raycast half of a vehicle tick. This must happen before
+    /// the car's wheel/air-control update so contact count and forward speed
+    /// describe the current tick, matching RocketSim v2's updateVehicleFirst.
+    pub fn update_first(&mut self, collision_world: &mut DiscreteDynamicsWorld, time_step: f32) {
+        let trace_call = FRIC_TRACE_CALLS.fetch_add(1, Ordering::Relaxed);
         let chassis = &collision_world.bodies()[self.chassis_body_idx];
         let chassis_trans = chassis.get_world_trans();
 
@@ -56,34 +56,257 @@ impl VehicleRL {
             (sources[i], targets[i]) = wheel.prepare_for_raycast(chassis_trans);
         }
 
+        if std::env::var("RSIM_DEBUG_WHEEL").is_ok() {
+            let chassis = &collision_world.bodies()[self.chassis_body_idx];
+            println!(
+                "rust_vehicle_first,body={},pos={:?},lin={:?},ang={:?},up={:?}",
+                self.chassis_body_idx,
+                chassis.get_world_trans().translation,
+                chassis.lin_vel,
+                chassis.ang_vel,
+                chassis.get_world_trans().matrix3.z_axis
+            );
+            for (i, wheel) in self.wheels.iter().enumerate() {
+                match wheel.raycast_info.as_ref() {
+                    Some(info) => println!(
+                        "rust_wheel_first,body={},wheel={},contact={},point={:?},normal={:?},susp={},susp_rel={},clip={},hard={:?},axle={:?},vel={:?},lat={},long={},extra={}",
+                        self.chassis_body_idx,
+                        i,
+                        info.is_in_contact_with_world,
+                        info.contact_point,
+                        info.contact_normal,
+                        info.suspension_length,
+                        info.suspension_relative_vel,
+                        info.clipped_inv_contact_dot_suspension,
+                        wheel.hard_point,
+                        wheel.axle_dir,
+                        wheel.vel_at_contact_point,
+                        wheel.lat_friction,
+                        wheel.long_friction,
+                        wheel.extra_pushback
+                    ),
+                    None => println!(
+                        "rust_wheel_first,body={},wheel={},contact=0",
+                        self.chassis_body_idx, i
+                    ),
+                }
+            }
+        }
+
         let ray_results = self
             .raycaster
             .cast_rays(collision_world, &sources, &targets, chassis);
 
         for (i, wheel) in self.wheels.iter_mut().enumerate() {
             if let Some(ray_result) = ray_results[i] {
-                wheel.apply_ray_cast(
-                    chassis,
-                    ray_result,
-                    time_step,
-                    i < 2,
-                    handbrake_val,
-                    real_throttle,
-                    three_wheels,
-                );
+                wheel.apply_ray_cast(chassis, ray_result, time_step, i < 2);
             } else {
                 wheel.reset_wheel_suspension();
             }
         }
 
+        // Narrow parity diagnostics: unlike RSIM_DEBUG_WHEEL (which prints the
+        // previous raycast state), this captures the freshly-applied raycast
+        // values that feed suspension/friction.  It is intentionally gated so
+        // normal simulation remains bit-for-bit inert.
+        if std::env::var("RSIM_DEBUG_WHEEL_AFTER").is_ok() {
+            let chassis = &collision_world.bodies()[self.chassis_body_idx];
+            println!(
+                "rust_wheel_after,body={},pos={:?},lin={:?},ang={:?},up={:?},invI={:?}",
+                self.chassis_body_idx,
+                chassis.get_world_trans().translation,
+                chassis.lin_vel,
+                chassis.ang_vel,
+                chassis.get_world_trans().matrix3.z_axis,
+                chassis.inv_inertia_tensor_world,
+            );
+            for (i, wheel) in self.wheels.iter().enumerate() {
+                match wheel.raycast_info.as_ref() {
+                    Some(info) => println!(
+                        "rust_wheel_after_data,body={},wheel={},contact={},point={:?},normal={:?},susp={},susp_rel={},clip={},force_scale={},extra={},hard={:?},vel={:?}",
+                        self.chassis_body_idx,
+                        i,
+                        info.is_in_contact_with_world,
+                        info.contact_point,
+                        info.contact_normal,
+                        info.suspension_length,
+                        info.suspension_relative_vel,
+                        info.clipped_inv_contact_dot_suspension,
+                        wheel.suspension_force_scale,
+                        wheel.extra_pushback,
+                        wheel.hard_point,
+                        wheel.vel_at_contact_point,
+                    ),
+                    None => println!(
+                        "rust_wheel_after_data,body={},wheel={},contact=0",
+                        self.chassis_body_idx, i
+                    ),
+                }
+            }
+        }
+
+        // RocketSim v2 calculates friction impulses in updateVehicleFirst,
+        // before Car::_UpdateWheels changes this tick's engine/brake/friction
+        // fields.  The values stored on each wheel are therefore the values
+        // from the previous tick, exactly as in the C++ vehicle path.
+        for (wheel_idx, wheel) in self.wheels.iter_mut().enumerate() {
+            let Some(info) = wheel.raycast_info.as_ref() else {
+                continue;
+            };
+            let chassis = &collision_world.bodies()[self.chassis_body_idx];
+            let ground = &collision_world.bodies()[info.ground_body_idx];
+            let impulse = wheel.calc_friction_impulses(
+                chassis,
+                ground,
+                info.contact_normal,
+                info.contact_point,
+                time_step,
+            );
+            if let Some(info) = wheel.raycast_info.as_mut() {
+                info.impulse = impulse;
+            }
+            if std::env::var("RSIM_FRIC_TRACE_CALL")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                == Some(trace_call)
+            {
+                let info = wheel.raycast_info.as_ref().unwrap();
+                println!(
+                    "rust_fric_trace,call={},body={},wheel={},axle=({:.17e}[{:08x}],{:.17e}[{:08x}],{:.17e}[{:08x}]),normal=({:.17e}[{:08x}],{:.17e}[{:08x}],{:.17e}[{:08x}]),point=({:.17e}[{:08x}],{:.17e}[{:08x}],{:.17e}[{:08x}]),engine={:.17e}[{:08x}],brake={:.17e}[{:08x}],lat={:.17e}[{:08x}],long={:.17e}[{:08x}],impulse=({:.17e}[{:08x}],{:.17e}[{:08x}],{:.17e}[{:08x}])",
+                    trace_call,
+                    self.chassis_body_idx,
+                    wheel_idx,
+                    wheel.axle_dir.x,
+                    wheel.axle_dir.x.to_bits(),
+                    wheel.axle_dir.y,
+                    wheel.axle_dir.y.to_bits(),
+                    wheel.axle_dir.z,
+                    wheel.axle_dir.z.to_bits(),
+                    info.contact_normal.x,
+                    info.contact_normal.x.to_bits(),
+                    info.contact_normal.y,
+                    info.contact_normal.y.to_bits(),
+                    info.contact_normal.z,
+                    info.contact_normal.z.to_bits(),
+                    info.contact_point.x,
+                    info.contact_point.x.to_bits(),
+                    info.contact_point.y,
+                    info.contact_point.y.to_bits(),
+                    info.contact_point.z,
+                    info.contact_point.z.to_bits(),
+                    wheel.engine_force,
+                    wheel.engine_force.to_bits(),
+                    wheel.brake,
+                    wheel.brake.to_bits(),
+                    wheel.lat_friction,
+                    wheel.lat_friction.to_bits(),
+                    wheel.long_friction,
+                    wheel.long_friction.to_bits(),
+                    impulse.x,
+                    impulse.x.to_bits(),
+                    impulse.y,
+                    impulse.y.to_bits(),
+                    impulse.z,
+                    impulse.z.to_bits()
+                );
+            }
+            if std::env::var("RSIM_DEBUG_WHEEL_AFTER").is_ok() {
+                println!(
+                    "rust_wheel_friction,body={},wheel={},static={},lat={},long={},engine={},brake={},impulse={:?}",
+                    self.chassis_body_idx,
+                    wheel_idx,
+                    ground.is_static_obj(),
+                    wheel.lat_friction,
+                    wheel.long_friction,
+                    wheel.engine_force,
+                    wheel.brake,
+                    impulse,
+                );
+            }
+        }
+    }
+
+    /// Calculate friction after the car has set engine/brake/handbrake state,
+    /// then apply suspension and friction impulses. This is the second half
+    /// of RocketSim v2's updateVehicleFirst/updateVehicleSecond sequence.
+    pub fn update_second(&mut self, collision_world: &mut DiscreteDynamicsWorld, time_step: f32) {
+        let chassis_idx = self.chassis_body_idx;
         let chassis = &mut collision_world.bodies_mut()[self.chassis_body_idx];
         for wheel in &mut self.wheels {
+            if std::env::var("RSIM_DEBUG_WHEEL_AFTER").is_ok() {
+                if let Some(info) = wheel.raycast_info.as_ref() {
+                    println!(
+                        "rust_wheel_susp_input,body={},susp={},susp_rel={},clip={},force_scale={},extra={},normal={:?}",
+                        self.chassis_body_idx,
+                        info.suspension_length,
+                        info.suspension_relative_vel,
+                        info.clipped_inv_contact_dot_suspension,
+                        wheel.suspension_force_scale,
+                        wheel.extra_pushback,
+                        info.contact_normal,
+                    );
+                }
+            }
             wheel.update_suspension(chassis, time_step);
+        }
+
+        if std::env::var("RSIM_DEBUG_WHEEL").is_ok() {
+            println!(
+                "rust_vehicle_suspension_post,body={},pos={:?},lin={:?},ang={:?},up={:?}",
+                self.chassis_body_idx,
+                chassis.get_world_trans().translation,
+                chassis.lin_vel,
+                chassis.ang_vel,
+                chassis.get_world_trans().matrix3.z_axis
+            );
         }
 
         // note: all suspension MUST be updated before impulses are applied
         for wheel in &mut self.wheels {
             wheel.apply_friction_impulses(chassis, time_step);
         }
+
+        if std::env::var("RSIM_DEBUG_WHEEL").is_ok() {
+            println!(
+                "rust_vehicle_second,body={},pos={:?},lin={:?},ang={:?},up={:?}",
+                self.chassis_body_idx,
+                chassis.get_world_trans().translation,
+                chassis.lin_vel,
+                chassis.ang_vel,
+                chassis.get_world_trans().matrix3.z_axis
+            );
+        }
+    }
+
+    /// Refresh per-wheel friction coefficients after the car's current
+    /// controls have been processed. This mirrors V2's `_UpdateWheels`; the
+    /// impulse itself was already computed in `update_first`.
+    pub fn update_friction_coefficients(
+        &mut self,
+        collision_world: &DiscreteDynamicsWorld,
+        handbrake_val: f32,
+        real_throttle: f32,
+        three_wheels: bool,
+    ) {
+        for wheel in &mut self.wheels {
+            if wheel.raycast_info.is_none() {
+                continue;
+            }
+            let chassis = &collision_world.bodies()[self.chassis_body_idx];
+            wheel.update_friction_coefficients(chassis, handbrake_val, real_throttle, three_wheels);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn update(
+        &mut self,
+        collision_world: &mut DiscreteDynamicsWorld,
+        time_step: f32,
+        _handbrake_val: f32,
+        _real_throttle: f32,
+        _three_wheels: bool,
+    ) {
+        self.update_first(collision_world, time_step);
+        self.update_second(collision_world, time_step);
     }
 }

--- a/rocketsim/src/bullet/dynamics/vehicle/wheel_info.rs
+++ b/rocketsim/src/bullet/dynamics/vehicle/wheel_info.rs
@@ -9,12 +9,13 @@ use crate::{
             },
             rigid_body::{Impulse, RigidBody},
         },
-        linear_math::QuatExt,
+        linear_math::{QuatExt, bullet_mat3_from_quat},
     },
     consts::{BT_TO_UU, UU_TO_BT, bullet_vehicle, curves},
 };
 
 pub struct RaycastInfo {
+    pub ground_body_idx: usize,
     pub contact_normal: Vec3A,
     pub contact_point: Vec3A,
     pub suspension_length: f32,
@@ -54,8 +55,12 @@ impl WheelInfo {
         brake: 0.0,
         steer_angle: 0.0,
         vel_at_contact_point: Vec3A::ZERO,
-        lat_friction: 1.0,
-        long_friction: 1.0,
+        // btWheelInfoRL initializes these to zero.  They are overwritten by
+        // Car::_UpdateWheels only while a ray has a ground object; keeping the
+        // Rust defaults at one applies an unintended first-contact friction
+        // impulse one tick before V2 does.
+        lat_friction: 0.0,
+        long_friction: 0.0,
         suspension_force_scale: 1.0,
         extra_pushback: 0.0,
         real_ray_length: 0.0,
@@ -75,7 +80,8 @@ impl WheelInfo {
 
         let suspension_travel = bullet_vehicle::MAX_SUSPENSION_TRAVEL * UU_TO_BT;
         self.real_ray_length =
-            self.suspension_rest_length_1 + suspension_travel + self.wheels_radius;
+            self.suspension_rest_length_1 + suspension_travel + self.wheels_radius
+                - bullet_vehicle::SUSPENSION_SUBTRACTION;
     }
 
     pub fn prepare_for_raycast(&mut self, chassis_trans: &Affine3A) -> (Vec3A, Vec3A) {
@@ -96,9 +102,6 @@ impl WheelInfo {
         ray_results: VehicleRaycasterResult,
         time_step: f32,
         front: bool,
-        handbrake_val: f32,
-        real_throttle: f32,
-        three_wheels: bool,
     ) {
         let contact_point = ray_results.hit_point_in_world;
         let contact_normal = ray_results.hit_normal_in_world;
@@ -106,8 +109,13 @@ impl WheelInfo {
 
         let chassis_trans = chassis.get_world_trans();
         self.axle_dir = if front {
-            Quat::from_axis_angle_simd(chassis_trans.matrix3.z_axis, self.steer_angle)
-                * chassis_trans.matrix3.y_axis
+            // btVehicleRL::updateWheelTransform builds a Bullet quaternion,
+            // converts it with btMatrix3x3::setRotation, and applies that
+            // matrix to basis2's right column. Use the same path instead of
+            // glam's quaternion-vector multiply (which rounds differently).
+            let steering =
+                Quat::from_axis_angle_bullet(chassis_trans.matrix3.z_axis, self.steer_angle);
+            bullet_mat3_from_quat(steering) * chassis_trans.matrix3.y_axis
         } else {
             chassis_trans.matrix3.y_axis
         };
@@ -154,13 +162,39 @@ impl WheelInfo {
             }
         }
 
-        // Refresh friction curves against THIS tick's fresh contact before
-        // the impulses are computed - consuming the previous grounded tick's
-        // values left first-touchdown ticks with stale (full-strength)
-        // friction.
+        self.raycast_info = Some(RaycastInfo {
+            ground_body_idx: ray_results.rigid_body.world_array_idx,
+            contact_normal,
+            contact_point,
+            suspension_length,
+            impulse: Vec3A::ZERO,
+            is_in_contact_with_world,
+            clipped_inv_contact_dot_suspension,
+            suspension_relative_vel,
+        });
+    }
+
+    /// Update the friction coefficients after the car has updated
+    /// engine/brake, steering, and handbrake state for this tick. The actual
+    /// friction impulse is intentionally calculated earlier by
+    /// `VehicleRL::update_first`, using the previous tick's coefficients.
+    pub fn update_friction_coefficients(
+        &mut self,
+        chassis: &RigidBody,
+        handbrake_val: f32,
+        real_throttle: f32,
+        three_wheels: bool,
+    ) {
+        let Some(info) = self.raycast_info.as_ref() else {
+            return;
+        };
+        let contact_normal = info.contact_normal;
         let lat_dir = self.axle_dir;
         let long_dir = lat_dir.cross(contact_normal);
-        let wheel_delta = contact_point - chassis.get_world_trans().translation;
+        // V2 evaluates the friction curve from the suspension hard point,
+        // not the ray hit point (the latter is only used for the impulse
+        // application). Preserve that distinction for parity.
+        let wheel_delta = self.hard_point - chassis.get_world_trans().translation;
         let cross_vec = (chassis.ang_vel.cross(wheel_delta) + chassis.lin_vel) * BT_TO_UU;
         let base_friction = cross_vec.dot(lat_dir).abs();
         let friction_curve_input = if base_friction > 5.0 {
@@ -168,46 +202,26 @@ impl WheelInfo {
         } else {
             0.0
         };
-        let mut lat_friction = if three_wheels {
+        self.lat_friction = if three_wheels {
             curves::LAT_FRICTION_THREEWHEEL
         } else {
             curves::LAT_FRICTION
         }
         .get_output(friction_curve_input);
-        let mut long_friction = 1.0;
+        self.long_friction = 1.0;
         if handbrake_val != 0.0 {
-            lat_friction *= 1.0
+            self.lat_friction *= 1.0
                 + (curves::HANDBRAKE_LAT_FRICTION_FACTOR.get_output(friction_curve_input) - 1.0)
                     * handbrake_val;
-            long_friction *= 1.0
+            self.long_friction *= 1.0
                 + (curves::HANDBRAKE_LONG_FRICTION_FACTOR.get_output(friction_curve_input) - 1.0)
                     * handbrake_val;
         }
         if real_throttle == 0.0 {
             let non_sticky_scale = curves::NON_STICKY_FRICTION_FACTOR.get_output(contact_normal.z);
-            lat_friction *= non_sticky_scale;
-            long_friction *= non_sticky_scale;
+            self.lat_friction *= non_sticky_scale;
+            self.long_friction *= non_sticky_scale;
         }
-        self.lat_friction = lat_friction;
-        self.long_friction = long_friction;
-
-        let impulse = self.calc_friction_impulses(
-            chassis,
-            ray_results.rigid_body,
-            contact_normal,
-            contact_point,
-            time_step,
-        );
-
-        self.raycast_info = Some(RaycastInfo {
-            contact_normal,
-            contact_point,
-            suspension_length,
-            impulse,
-            is_in_contact_with_world,
-            clipped_inv_contact_dot_suspension,
-            suspension_relative_vel,
-        });
     }
 
     pub fn calc_friction_impulses(
@@ -219,7 +233,12 @@ impl WheelInfo {
         time_step: f32,
     ) -> Vec3A {
         let friction_scale = chassis.get_mass() / 3.0;
-        let axle_dir = self.axle_dir.normalize_or_zero();
+        // V2 projects the wheel's raw axle basis onto the contact plane before
+        // normalizing it.  The raw steer axis is still used for the friction
+        // coefficient curve, but the impulse basis must be tangent to the
+        // surface normal.
+        let axle_dir = (self.axle_dir - contact_normal * self.axle_dir.dot(contact_normal))
+            .normalize_or_zero();
 
         let forward_dir = contact_normal.cross(axle_dir).normalize_or_zero();
 

--- a/rocketsim/src/bullet/linear_math/mod.rs
+++ b/rocketsim/src/bullet/linear_math/mod.rs
@@ -7,5 +7,10 @@ mod util;
 pub(super) use affine_ext::AffineExt;
 pub(super) use obb::Obb;
 pub(super) use quat_ext::QuatExt;
-pub(super) use transform_util::{integrate_trans, integrate_trans_no_rot};
-pub(super) use util::{interpolate_3, max_dot, plane_space_1};
+pub(super) use transform_util::{
+    bullet_mat3_from_quat, bullet_quat_from_mat3, integrate_trans, integrate_trans_no_rot,
+};
+pub(crate) use util::{
+    bullet_dot, bullet_length_squared, bullet_normalize, bullet_safe_normalize, interpolate_3,
+    max_dot, plane_space_1,
+};

--- a/rocketsim/src/bullet/linear_math/quat_ext.rs
+++ b/rocketsim/src/bullet/linear_math/quat_ext.rs
@@ -2,6 +2,11 @@ use glam::{Quat, Vec3A};
 
 pub trait QuatExt {
     fn from_axis_angle_simd(axis: Vec3A, angle: f32) -> Self;
+    /// Construct an axis-angle quaternion using Bullet's btQuaternion(axis,
+    /// angle) sequence. Bullet divides by the axis length before multiplying
+    /// the sine term; glam's constructor assumes a unit axis and therefore
+    /// can differ by an ulp when a live chassis basis has drifted slightly.
+    fn from_axis_angle_bullet(axis: Vec3A, angle: f32) -> Self;
 }
 
 impl QuatExt for Quat {
@@ -12,5 +17,15 @@ impl QuatExt for Quat {
         let (s, c) = f32::sin_cos(angle * 0.5);
         let v = axis * s;
         Self::from_xyzw(v.x, v.y, v.z, c)
+    }
+
+    #[inline]
+    fn from_axis_angle_bullet(axis: Vec3A, angle: f32) -> Self {
+        // btQuaternion::setRotation uses btSin/btCos independently and
+        // divides by d = axis.length(). Keep the same operation order.
+        let half = angle * 0.5;
+        let d = axis.length();
+        let s = half.sin() / d;
+        Self::from_xyzw(axis.x * s, axis.y * s, axis.z * s, half.cos())
     }
 }

--- a/rocketsim/src/bullet/linear_math/transform_util.rs
+++ b/rocketsim/src/bullet/linear_math/transform_util.rs
@@ -2,7 +2,209 @@ use std::f32::consts::FRAC_PI_4;
 
 use glam::{Affine3A, Mat3A, Quat, Vec3A};
 
+use super::util::bullet_length_squared;
+
 const ANGULAR_MOTION_THRESHOLD: f32 = FRAC_PI_4;
+
+/// Match btMatrix3x3::getRotation, including its row/column convention and
+/// operation ordering.  Rust stores the basis in Mat3A columns; Bullet's
+/// `m_el` is addressed as rows, so the entries are transposed on read.
+pub(crate) fn bullet_quat_from_mat3(m: Mat3A) -> Quat {
+    let m00 = m.x_axis.x;
+    let m01 = m.y_axis.x;
+    let m02 = m.z_axis.x;
+    let m10 = m.x_axis.y;
+    let m11 = m.y_axis.y;
+    let m12 = m.z_axis.y;
+    let m20 = m.x_axis.z;
+    let m21 = m.y_axis.z;
+    let m22 = m.z_axis.z;
+
+    let trace = m00 + m11 + m22;
+    let (x, y, z, w, root) = if trace > 0.0 {
+        (m21 - m12, m02 - m20, m10 - m01, trace + 1.0, trace + 1.0)
+    } else {
+        let (i, j, k) = if m00 < m11 {
+            if m11 < m22 { (2, 0, 1) } else { (1, 2, 0) }
+        } else if m00 < m22 {
+            (2, 0, 1)
+        } else {
+            (0, 1, 2)
+        };
+        let diag = [[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]];
+        let root = diag[i][i] - diag[j][j] - diag[k][k] + 1.0;
+        let mut t = [0.0f32; 4];
+        t[3] = diag[k][j] - diag[j][k];
+        t[j] = diag[j][i] + diag[i][j];
+        t[k] = diag[k][i] + diag[i][k];
+        t[i] = root;
+        (t[0], t[1], t[2], t[3], root)
+    };
+
+    let s = 0.5 / root.sqrt();
+    Quat::from_xyzw(x * s, y * s, z * s, w * s)
+}
+
+/// Bullet's SSE quaternion product operation order.  The grouping mirrors
+/// btQuaternion's SIMD path (AB0/AB3 and AB1/AB2 are formed separately before
+/// the final add), which is observable at low angular velocities.
+#[inline]
+fn bullet_quat_mul(q1: Quat, q2: Quat) -> Quat {
+    let a1 = [
+        q1.x * q2.w + q1.y * q2.z,
+        q1.y * q2.w + q1.z * q2.x,
+        q1.z * q2.w + q1.x * q2.y,
+        q1.x * q2.x + q1.y * q2.y,
+    ];
+    let a0 = [
+        q1.w * q2.x - q1.z * q2.y,
+        q1.w * q2.y - q1.x * q2.z,
+        q1.w * q2.z - q1.y * q2.x,
+        q1.w * q2.w - q1.z * q2.z,
+    ];
+    Quat::from_xyzw(a0[0] + a1[0], a0[1] + a1[1], a0[2] + a1[2], a0[3] - a1[3])
+}
+
+/// Normalize a quaternion using the same horizontal reduction as Bullet's
+/// `btQuaternion::normalize()` SSE path.  glam's `Quat::normalize()` routes
+/// through its generic `Vec4` dot helper; that helper is algebraically
+/// equivalent but can round the horizontal sum in a different order.  The
+/// difference is visible as a one-ulp basis change after low-speed wheel
+/// contacts and then gets amplified by later collision callbacks.
+#[inline]
+fn bullet_quat_normalize(q: Quat) -> Quat {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        use core::arch::x86_64::*;
+
+        unsafe {
+            let qv = _mm_set_ps(q.w, q.z, q.y, q.x);
+            let mut vd = _mm_mul_ps(qv, qv);
+            // Bullet: (x*x + z*z) + (y*y + w*w), via movehl/add/shuffle/addss.
+            let t = _mm_movehl_ps(vd, vd);
+            vd = _mm_add_ps(vd, t);
+            let t = _mm_shuffle_ps(vd, vd, 0x55);
+            vd = _mm_add_ss(vd, t);
+            vd = _mm_sqrt_ss(vd);
+            vd = _mm_div_ss(_mm_set_ss(1.0), vd);
+            vd = _mm_shuffle_ps(vd, vd, 0x00);
+            let out = _mm_mul_ps(qv, vd);
+            let mut values = [0.0f32; 4];
+            _mm_storeu_ps(values.as_mut_ptr(), out);
+            Quat::from_xyzw(values[0], values[1], values[2], values[3])
+        }
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        q / q.length()
+    }
+}
+
+/// Bullet's quaternion-to-basis conversion (the scalar formula, with the
+/// same `s = 2 / length2` normalization compensation).  `Mat3A` is column
+/// major, while Bullet stores basis rows, so the values are emitted as the
+/// transposed columns.
+#[inline]
+pub(crate) fn bullet_mat3_from_quat(q: Quat) -> Mat3A {
+    // On the supported desktop target, use the same SSE instruction sequence
+    // as btMatrix3x3::setRotation.  This avoids the last-ulp differences that
+    // remain even when the scalar expression has the same algebraic grouping.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        use core::arch::x86_64::*;
+
+        unsafe {
+            let qv = _mm_set_ps(q.w, q.z, q.y, q.x);
+            let nq = _mm_xor_ps(qv, _mm_set1_ps(-0.0));
+
+            let vd = _mm_mul_ps(qv, qv);
+            let t = _mm_movehl_ps(vd, vd);
+            let vd = _mm_add_ps(vd, t);
+            let t = _mm_shuffle_ps(vd, vd, 0x55);
+            let vd = _mm_add_ss(vd, t);
+            let d = _mm_cvtss_f32(vd);
+            let s = 2.0 / d;
+
+            let mut v1 = _mm_shuffle_ps(qv, qv, 0xE1); // Y X Z W
+            let mut v2 = _mm_shuffle_ps(nq, qv, 0xD0); // -X -X Y W
+            let mut v3 = _mm_shuffle_ps(qv, qv, 0xC6); // Z Y X W
+            v1 = _mm_xor_ps(v1, _mm_set_ps(0.0, 0.0, 0.0, -0.0));
+
+            let v11 = _mm_shuffle_ps(qv, qv, 0xC5); // Y Y X W
+            let mut v21 = _mm_unpackhi_ps(qv, qv); // Z Z W W
+            let mut v31 = _mm_shuffle_ps(qv, nq, 0xC8); // X Z -X -W
+
+            v2 = _mm_mul_ps(v2, v1);
+            v1 = _mm_mul_ps(v1, v11);
+            v3 = _mm_mul_ps(v3, v31);
+
+            let v11b = _mm_shuffle_ps(nq, qv, 0xDE); // -Z -W Y W
+            let v11b = _mm_mul_ps(v11b, v21);
+            v21 = _mm_xor_ps(v21, _mm_set_ps(0.0, 0.0, 0.0, -0.0));
+            v31 = _mm_shuffle_ps(qv, nq, 0xDF); // W W -Y -W
+            v31 = _mm_xor_ps(v31, _mm_set_ps(0.0, 0.0, 0.0, -0.0));
+            let y = _mm_shuffle_ps(nq, nq, 0xCB); // -W -Z -X -W
+            let z = _mm_shuffle_ps(qv, qv, 0xD1); // Y X Y W
+
+            v21 = _mm_mul_ps(v21, y);
+            v31 = _mm_mul_ps(v31, z);
+
+            v1 = _mm_add_ps(v1, v11b);
+            v2 = _mm_add_ps(v2, v21);
+            v3 = _mm_add_ps(v3, v31);
+
+            let vs = _mm_set1_ps(s);
+            v1 = _mm_add_ps(_mm_mul_ps(v1, vs), _mm_set_ps(0.0, 0.0, 0.0, 1.0));
+            v2 = _mm_add_ps(_mm_mul_ps(v2, vs), _mm_set_ps(0.0, 0.0, 1.0, 0.0));
+            v3 = _mm_add_ps(_mm_mul_ps(v3, vs), _mm_set_ps(0.0, 1.0, 0.0, 0.0));
+
+            let mut r1 = [0.0f32; 4];
+            let mut r2 = [0.0f32; 4];
+            let mut r3 = [0.0f32; 4];
+            _mm_storeu_ps(r1.as_mut_ptr(), v1);
+            _mm_storeu_ps(r2.as_mut_ptr(), v2);
+            _mm_storeu_ps(r3.as_mut_ptr(), v3);
+            return Mat3A::from_cols(
+                Vec3A::new(r1[0], r2[0], r3[0]),
+                Vec3A::new(r1[1], r2[1], r3[1]),
+                Vec3A::new(r1[2], r2[2], r3[2]),
+            );
+        }
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        // Bullet's SIMD dot product reduces as (x*x + z*z) + (y*y + w*w).
+        // Keep that grouping instead of glam's generic length_squared helper.
+        let x2 = q.x * q.x;
+        let y2 = q.y * q.y;
+        let z2 = q.z * q.z;
+        let w2 = q.w * q.w;
+        let d = (x2 + z2) + (y2 + w2);
+        let s = 2.0 / d;
+
+        // btMatrix3x3's SSE path forms the products first, adds the signed
+        // terms, and only then multiplies each row by s.  The scalar-looking
+        // formula (q.x * (q.y * s), etc.) rounds differently and accumulates a
+        // visible orientation drift over a replay.
+        let r00 = 1.0 + ((-y2 - z2) * s);
+        let r01 = ((q.x * q.y) + (-(q.w * q.z))) * s;
+        let r02 = ((q.x * q.z) + (q.w * q.y)) * s;
+        let r10 = ((q.x * q.y) + (q.w * q.z)) * s;
+        let r11 = 1.0 + ((-x2 - z2) * s);
+        let r12 = ((q.y * q.z) + (-(q.w * q.x))) * s;
+        let r20 = ((q.x * q.z) + (-(q.w * q.y))) * s;
+        let r21 = ((q.y * q.z) + (q.w * q.x)) * s;
+        let r22 = 1.0 + ((-x2 - y2) * s);
+
+        return Mat3A::from_cols(
+            Vec3A::new(r00, r10, r20),
+            Vec3A::new(r01, r11, r21),
+            Vec3A::new(r02, r12, r22),
+        );
+    }
+}
 
 #[inline]
 pub fn integrate_trans_no_rot(cur_trans: &mut Vec3A, lin_vel: Vec3A, time_step: f32) {
@@ -18,7 +220,17 @@ pub fn integrate_trans(
 ) {
     integrate_trans_no_rot(&mut cur_trans.translation, lin_vel, time_step);
 
-    let mut angle = ang_vel.length();
+    // Bullet's exponential-map path first checks fAngle2 against
+    // SIMD_EPSILON and only then takes the square root.  In particular, the
+    // tiny angular velocities generated by resting wheel contacts become an
+    // exact zero here; using ang_vel.length() directly leaves a small Taylor
+    // correction that accumulates into replay drift.
+    let f_angle2 = bullet_length_squared(ang_vel);
+    let mut angle = if f_angle2 > f32::EPSILON {
+        f_angle2.sqrt()
+    } else {
+        0.0
+    };
 
     if angle * time_step > ANGULAR_MOTION_THRESHOLD {
         angle = ANGULAR_MOTION_THRESHOLD / time_step;
@@ -26,14 +238,13 @@ pub fn integrate_trans(
 
     let axis = if angle < 0.001 {
         ang_vel
-            * (0.5 * time_step - time_step * time_step * time_step * 0.020_833_334)
-            * angle
-            * angle
+            * (0.5 * time_step
+                - time_step * time_step * time_step * 0.020_833_333_333 * angle * angle)
     } else {
         ang_vel * ((0.5 * angle * time_step).sin() / angle)
     };
 
     let dorn = Quat::from_xyzw(axis.x, axis.y, axis.z, (angle * time_step * 0.5).cos());
-    *cur_rot = (dorn * *cur_rot).normalize();
-    cur_trans.matrix3 = Mat3A::from_quat(*cur_rot);
+    *cur_rot = bullet_quat_normalize(bullet_quat_mul(dorn, *cur_rot));
+    cur_trans.matrix3 = bullet_mat3_from_quat(*cur_rot);
 }

--- a/rocketsim/src/bullet/linear_math/util.rs
+++ b/rocketsim/src/bullet/linear_math/util.rs
@@ -2,6 +2,92 @@ use std::f32::consts::FRAC_1_SQRT_2;
 
 use glam::{Vec3A, Vec4};
 
+/// Match Bullet's btVector3::normalize() on the x86 SIMD build: an SSE
+/// reciprocal-square-root followed by one Newton-Raphson refinement.
+#[inline]
+pub fn bullet_dot(a: Vec3A, b: Vec3A) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        use std::arch::x86_64::{
+            _mm_add_ss, _mm_cvtss_f32, _mm_movehl_ps, _mm_mul_ps, _mm_setr_ps, _mm_shuffle_ps,
+        };
+
+        // btVector3::dot() uses the SSE lanes in this order (x + y) + z.
+        let av = _mm_setr_ps(a.x, a.y, a.z, 0.0);
+        let bv = _mm_setr_ps(b.x, b.y, b.z, 0.0);
+        let products = _mm_mul_ps(av, bv);
+        let z = _mm_movehl_ps(products, products);
+        let y = _mm_shuffle_ps(products, products, 0x55);
+        let sum = _mm_add_ss(_mm_add_ss(products, y), z);
+        _mm_cvtss_f32(sum)
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let products = a * b;
+        products.x + (products.y + products.z)
+    }
+}
+
+#[inline]
+pub fn bullet_length_squared(v: Vec3A) -> f32 {
+    bullet_dot(v, v)
+}
+
+/// Match Bullet's `btVector3::safeNormalize()` used by the V2 gameplay
+/// car-ball impulse.  This is deliberately different from Bullet's
+/// `normalize()` SSE fast path: `safeNormalize()` computes a scalar sqrt and
+/// then scales the vector by its reciprocal.
+#[inline]
+pub fn bullet_safe_normalize(v: Vec3A) -> Vec3A {
+    let len_sq = bullet_length_squared(v);
+    if len_sq >= f32::EPSILON * f32::EPSILON {
+        v * (1.0 / len_sq.sqrt())
+    } else {
+        Vec3A::X
+    }
+}
+
+/// Match Bullet's btVector3::normalize() on the x86 SIMD build: an SSE
+/// reciprocal-square-root followed by one Newton-Raphson refinement.
+#[inline]
+pub fn bullet_normalize(v: Vec3A) -> Vec3A {
+    #[cfg(target_arch = "x86_64")]
+    unsafe {
+        use std::arch::x86_64::{
+            _mm_add_ss, _mm_cvtss_f32, _mm_movehl_ps, _mm_mul_ps, _mm_mul_ss, _mm_rsqrt_ss,
+            _mm_set_ss, _mm_setr_ps, _mm_shuffle_ps, _mm_sub_ss,
+        };
+
+        // Bullet's SSE path forms the dot product in a very specific order:
+        // multiply all lanes, add Y into X, then add Z.  Keep that sequence
+        // instead of relying on scalar/FMA reassociation, because the normal
+        // is fed directly into GJK and contact impulses.
+        let vv = _mm_setr_ps(v.x, v.y, v.z, 0.0);
+        let vd = _mm_mul_ps(vv, vv);
+        let z = _mm_movehl_ps(vd, vd);
+        let y = _mm_shuffle_ps(vd, vd, 0x55);
+        let vd = _mm_add_ss(vd, y);
+        let vd = _mm_add_ss(vd, z);
+        let len_sq = _mm_cvtss_f32(vd);
+        if len_sq == 0.0 {
+            return Vec3A::ZERO;
+        }
+        let len_sq = _mm_set_ss(len_sq);
+        let mut inv_len = _mm_rsqrt_ss(len_sq);
+        let half_len_sq = _mm_mul_ss(_mm_mul_ss(len_sq, _mm_set_ss(0.5)), inv_len);
+        let correction = _mm_mul_ss(half_len_sq, inv_len);
+        inv_len = _mm_mul_ss(inv_len, _mm_sub_ss(_mm_set_ss(1.5), correction));
+
+        v * _mm_cvtss_f32(inv_len)
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        v.normalize_or_zero()
+    }
+}
+
 #[inline]
 pub fn interpolate_3(v0: Vec3A, v1: Vec3A, rt: f32) -> Vec3A {
     let s = 1.0 - rt;

--- a/rocketsim/src/shared/bvh.rs
+++ b/rocketsim/src/shared/bvh.rs
@@ -24,7 +24,18 @@ impl Tree {
     const TRAVERSAL_STACK_SIZE: usize = 128;
 
     pub fn build(aabb: Aabb, leaf_nodes: &mut [Node]) -> Self {
-        let binary = BinaryTree::build(aabb, leaf_nodes);
+        Self::build_with_mode(aabb, leaf_nodes, false)
+    }
+
+    /// Build using Bullet's btQuantizedBvh split heuristic.  The resulting
+    /// binary pre-order is useful when matching Bullet's triangle callback
+    /// order; callers that do not need Bullet ordering should use `build`.
+    pub fn build_bullet(aabb: Aabb, leaf_nodes: &mut [Node]) -> Self {
+        Self::build_with_mode(aabb, leaf_nodes, true)
+    }
+
+    fn build_with_mode(aabb: Aabb, leaf_nodes: &mut [Node], bullet_order: bool) -> Self {
+        let binary = BinaryTree::build_with_mode(aabb, leaf_nodes, bullet_order);
         let mut wide_nodes = Vec::new();
         let mut leaves = Vec::with_capacity(leaf_nodes.len());
         let max_wide_depth = binary.build_wide_node(0, &mut wide_nodes, &mut leaves);
@@ -155,6 +166,56 @@ impl Tree {
         mid
     }
 
+    fn calc_bullet_split(leaf_nodes: &mut [Node], start_idx: usize, end_idx: usize) -> usize {
+        let count = end_idx - start_idx;
+        debug_assert!(count >= 2);
+
+        // This mirrors btQuantizedBvh::calcSplittingAxis.  Bullet computes
+        // centroids from the (quantized) leaf bounds and chooses the largest
+        // sample variance.  The explicit comparisons preserve btVector3's
+        // maxAxis tie-breaking (x, then y, then z).
+        let mut means = Vec3A::ZERO;
+        for leaf in &leaf_nodes[start_idx..end_idx] {
+            means += (leaf.aabb.min + leaf.aabb.max) * 0.5;
+        }
+        means *= 1.0 / count as f32;
+
+        let mut variance = Vec3A::ZERO;
+        for leaf in &leaf_nodes[start_idx..end_idx] {
+            let diff = (leaf.aabb.min + leaf.aabb.max) * 0.5 - means;
+            variance += diff * diff;
+        }
+        variance *= 1.0 / (count - 1) as f32;
+
+        let split_axis = if variance.x < variance.y {
+            if variance.y < variance.z { 2 } else { 1 }
+        } else if variance.x < variance.z {
+            2
+        } else {
+            0
+        };
+
+        let split_value = means[split_axis];
+        let mut split_idx = start_idx;
+        for i in start_idx..end_idx {
+            let center = (leaf_nodes[i].aabb.min + leaf_nodes[i].aabb.max) * 0.5;
+            if center[split_axis] > split_value {
+                if i != split_idx {
+                    Self::swap_leaf_nodes(leaf_nodes, i, split_idx);
+                }
+                split_idx += 1;
+            }
+        }
+
+        let range_balanced = count / 3;
+        if split_idx <= start_idx + range_balanced || split_idx >= end_idx - 1 - range_balanced {
+            start_idx + (count >> 1)
+        } else {
+            debug_assert!(split_idx > start_idx && split_idx < end_idx);
+            split_idx
+        }
+    }
+
     fn swap_leaf_nodes(leaf_nodes: &mut [Node], i: usize, split_idx: usize) {
         debug_assert_ne!(i, split_idx);
         let [a, b] = unsafe { leaf_nodes.get_disjoint_unchecked_mut([split_idx, i]) };
@@ -215,6 +276,38 @@ impl Tree {
         }
     }
 
+    /// Collect the triangle/leaf indices overlapping an AABB without invoking
+    /// a callback.  This is used by the triangle-mesh adapter when it needs a
+    /// deterministic ordering independent of the wide-BVH traversal layout.
+    pub fn collect_aabb_overlapping_indices(&self, aabb: &Aabb) -> Vec<usize> {
+        let mut indices = Vec::new();
+        if !aabb.intersects(&self.aabb) {
+            return indices;
+        }
+
+        let mut stack = [WideChild::default(); Self::TRAVERSAL_STACK_SIZE];
+        stack[0] = WideChild::branch(0);
+        let mut stack_len = 1;
+        while stack_len != 0 {
+            stack_len -= 1;
+            let work = stack[stack_len];
+            if let Some(storage_idx) = work.leaf_idx() {
+                indices.push(self.leaves[storage_idx].leaf_idx);
+                continue;
+            }
+
+            let node = &self.wide_nodes[work.branch_idx()];
+            let mask = node.intersection_mask(aabb);
+            for lane in (0..node.child_count as usize).rev() {
+                if mask & (1 << lane) != 0 {
+                    stack[stack_len] = node.children[lane];
+                    stack_len += 1;
+                }
+            }
+        }
+        indices
+    }
+
     pub fn report_quad_ray_overlapping_node<T: ProcessQuadRayNode>(
         &self,
         node_callback: &mut T,
@@ -265,18 +358,24 @@ struct BinaryTree {
 }
 
 impl BinaryTree {
-    fn build(aabb: Aabb, leaf_nodes: &mut [Node]) -> Self {
+    fn build_with_mode(aabb: Aabb, leaf_nodes: &mut [Node], bullet_order: bool) -> Self {
         assert!(!leaf_nodes.is_empty());
         let mut tree = Self {
             aabb,
             cur_node_idx: 0,
             nodes: repeat_n(Node::DEFAULT, 2 * leaf_nodes.len()).collect(),
         };
-        tree.build_subtree(leaf_nodes, 0, leaf_nodes.len());
+        tree.build_subtree(leaf_nodes, 0, leaf_nodes.len(), bullet_order);
         tree
     }
 
-    fn build_subtree(&mut self, leaf_nodes: &mut [Node], start_idx: usize, end_idx: usize) {
+    fn build_subtree(
+        &mut self,
+        leaf_nodes: &mut [Node],
+        start_idx: usize,
+        end_idx: usize,
+        bullet_order: bool,
+    ) {
         let num_indices = end_idx - start_idx;
         let cur_idx = self.cur_node_idx;
 
@@ -286,7 +385,11 @@ impl BinaryTree {
             return;
         }
 
-        let split_idx = Tree::calc_sah_split(leaf_nodes, start_idx, end_idx);
+        let split_idx = if bullet_order {
+            Tree::calc_bullet_split(leaf_nodes, start_idx, end_idx)
+        } else {
+            Tree::calc_sah_split(leaf_nodes, start_idx, end_idx)
+        };
         let internal_node_idx = self.cur_node_idx;
 
         {
@@ -299,8 +402,8 @@ impl BinaryTree {
         }
 
         self.cur_node_idx += 1;
-        self.build_subtree(leaf_nodes, start_idx, split_idx);
-        self.build_subtree(leaf_nodes, split_idx, end_idx);
+        self.build_subtree(leaf_nodes, start_idx, split_idx, bullet_order);
+        self.build_subtree(leaf_nodes, split_idx, end_idx, bullet_order);
 
         self.nodes[internal_node_idx].node_type = BvhNodeType::Branch {
             escape_idx: self.cur_node_idx - cur_idx,

--- a/rocketsim/src/sim/arena/arena_contact_tracker.rs
+++ b/rocketsim/src/sim/arena/arena_contact_tracker.rs
@@ -1,5 +1,7 @@
 use std::mem;
 
+use glam::Vec3A;
+
 use crate::{
     bullet::{
         collision::{
@@ -21,6 +23,13 @@ pub(crate) struct ContactRecord {
     pub rb_idx_a: usize,
     pub rb_idx_b: usize,
     pub manifold_point: ManifoldPoint,
+    /// RocketSim V2 invokes semantic contact handling before Bullet integrates
+    /// transforms. Rust drains contact records after the step, so retain the
+    /// pre-solver body values for equivalent hit calculations.
+    pub pre_pos_a: Vec3A,
+    pub pre_vel_a: Vec3A,
+    pub pre_pos_b: Vec3A,
+    pub pre_vel_b: Vec3A,
 }
 
 // A struct to be accessed through the bullet contact callbacks
@@ -90,7 +99,30 @@ impl ContactAddedCallback for ArenaContactTracker {
             rb_idx_a: body_a.world_array_idx,
             rb_idx_b: body_b.world_array_idx,
             manifold_point: *manifold_point,
+            pre_pos_a: body_a.get_world_trans().translation,
+            pre_vel_a: body_a.lin_vel,
+            pre_pos_b: body_b.get_world_trans().translation,
+            pre_vel_b: body_b.lin_vel,
         });
+
+        if std::env::var("RSIM_DEBUG_CONTACT").is_ok() {
+            println!(
+                "rust_contact,a={},b={},swap={},idx={:?},special={},point_a={:?},point_b={:?},normal={:?},distance={},friction={},restitution={},pre_a={:?},pre_b={:?}",
+                body_a.world_array_idx,
+                body_b.world_array_idx,
+                should_swap,
+                idx,
+                manifold_point.is_special,
+                manifold_point.pos_world_on_a,
+                manifold_point.pos_world_on_b,
+                manifold_point.normal_world_on_b,
+                manifold_point.distance_1,
+                manifold_point.combined_friction,
+                manifold_point.combined_restitution,
+                body_a.get_world_trans().translation,
+                body_b.get_world_trans().translation,
+            );
+        }
 
         if let Some(idx) = idx {
             adjust_internal_edge_contacts(manifold_point, body_b, idx);

--- a/rocketsim/src/sim/arena/base.rs
+++ b/rocketsim/src/sim/arena/base.rs
@@ -6,7 +6,7 @@ use glam::{Affine3A, EulerRot, Mat3A, Vec3A};
 #[cfg(debug_assertions)]
 use indexmap::IndexMap;
 
-use super::ArenaContactTracker;
+use super::{ArenaContactTracker, ContactRecord};
 use crate::{
     ARENA_COLLISION_SHAPES, ArenaConfig,
     ArenaEvent::{BallHitWorld, CarPickupBoost},
@@ -28,7 +28,6 @@ use crate::{
     },
     consts::{self, BT_TO_UU, TICK_RATE, TICK_TIME, UU_TO_BT},
     make_tile_shapes,
-    shared::quantize,
     sim::{
         ArenaEvent, Ball, BallState, BoostPad, CarHitBallEvent, CarHitCarEvent, CarHitWorldEvent,
         DemoMode, UserInfoTypes, arena::ArenaEventList,
@@ -476,21 +475,19 @@ impl Arena {
         // TODO: Make it not need to be called manually
         self.bullet_world.clear_accum_forces();
 
-        // Limit velocities, then quantize physics values
+        // Limit velocities after each physics step.
         {
             use consts::{ball, car};
 
             for car_idx in 0..self.cars.len() {
                 let car_rb = &mut self.bullet_world.bodies_mut()[self.cars[car_idx].rigid_body_idx];
                 car_rb.limit_vels(car::MAX_SPEED * UU_TO_BT, car::MAX_ANG_SPEED);
-                quantize::quantize(car_rb);
             }
             let ball_rb = &mut self.bullet_world.bodies_mut()[self.ball.rigid_body_idx];
             ball_rb.limit_vels(
                 self.config.mutators.ball_max_speed * UU_TO_BT,
                 ball::MAX_ANG_SPEED,
             );
-            quantize::quantize(ball_rb);
         }
 
         {
@@ -516,8 +513,36 @@ impl Arena {
             self.config.game_mode,
         );
 
+        if std::env::var("RSIM_DEBUG_SPECIAL_DETAIL").is_ok()
+            && (2125..=2132).contains(&self.tick_count)
+        {
+            let rb = &self.bullet_world.bodies()[self.ball.rigid_body_idx];
+            println!(
+                "rust_tick_before,tick={},pos={:?},lin={:?},ang={:?},active={:?}",
+                self.tick_count,
+                rb.get_world_trans().translation,
+                rb.lin_vel,
+                rb.ang_vel,
+                rb.is_active(),
+            );
+        }
+
         self.bullet_world
             .step_simulation(TICK_TIME, &mut self.contact_tracker);
+
+        if std::env::var("RSIM_DEBUG_SPECIAL_DETAIL").is_ok()
+            && (2125..=2132).contains(&self.tick_count)
+        {
+            let rb = &self.bullet_world.bodies()[self.ball.rigid_body_idx];
+            println!(
+                "rust_tick_after_world,tick={},pos={:?},lin={:?},ang={:?},active={:?}",
+                self.tick_count,
+                rb.get_world_trans().translation,
+                rb.lin_vel,
+                rb.ang_vel,
+                rb.is_active(),
+            );
+        }
 
         let contact_count = self.contact_tracker.num_records();
         for idx in 0..contact_count {
@@ -534,11 +559,7 @@ impl Arena {
             match user_idx_a {
                 UserInfoTypes::Car => match user_idx_b {
                     UserInfoTypes::Ball => {
-                        self.on_car_ball_collision(
-                            user_pointer_a,
-                            &contact.manifold_point,
-                            contact.is_swap,
-                        );
+                        self.on_car_ball_collision(user_pointer_a, &contact);
                     }
                     UserInfoTypes::Car => {
                         self.on_car_car_collision(
@@ -554,7 +575,7 @@ impl Arena {
                         self.on_ball_tile_collision(user_pointer_b);
                     }
                     UserInfoTypes::None => {
-                        self.on_ball_world_collision(&contact.manifold_point, contact.rb_idx_a);
+                        self.on_ball_world_collision(&contact);
                     }
                     _ => {}
                 },
@@ -586,7 +607,8 @@ impl Arena {
         }
 
         let ball_rb = &mut self.bullet_world.bodies_mut()[self.ball.rigid_body_idx];
-        self.ball.finish_physics_tick(ball_rb);
+        self.ball
+            .finish_physics_tick(ball_rb, &self.config.mutators);
 
         if self.config.game_mode == GameMode::Dropshot
             && self.ball.state.ds_info.last_damage_tick == Some(self.tick_count)
@@ -862,13 +884,39 @@ impl Arena {
         );
     }
 
-    fn on_ball_world_collision(&mut self, manifold_point: &ManifoldPoint, rb_index: usize) {
-        let contact_point = manifold_point.pos_world_on_b * BT_TO_UU;
-        let contact_normal = manifold_point.normal_world_on_b;
+    fn on_ball_world_collision(&mut self, contact: &ContactRecord) {
+        if std::env::var("RSIM_CONTACT_DEBUG_STEP")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(self.tick_count)
+        {
+            println!(
+                "rust_ball_world_contact,tick={},distance={},a={},b={},swap={},point_a={:?},point_b={:?},normal={:?},pre_a={:?},pre_b={:?},vel_a={:?},vel_b={:?}",
+                self.tick_count,
+                contact.manifold_point.distance_1,
+                contact.rb_idx_a,
+                contact.rb_idx_b,
+                contact.is_swap,
+                contact.manifold_point.pos_world_on_a,
+                contact.manifold_point.pos_world_on_b,
+                contact.manifold_point.normal_world_on_b,
+                contact.pre_pos_a,
+                contact.pre_pos_b,
+                contact.pre_vel_a,
+                contact.pre_vel_b,
+            );
+        }
+        let contact_point = contact.manifold_point.pos_world_on_b * BT_TO_UU;
+        let contact_normal = contact.manifold_point.normal_world_on_b;
 
-        let rb = &mut self.bullet_world.bodies_mut()[rb_index];
-        self.ball
-            .on_world_hit(rb, self.config.game_mode, contact_normal);
+        let rb = &mut self.bullet_world.bodies_mut()[contact.rb_idx_a];
+        self.ball.on_world_hit(
+            rb,
+            self.config.game_mode,
+            contact_normal,
+            contact.pre_pos_a,
+            contact.pre_vel_a,
+        );
 
         self.events.push(BallHitWorld(BallHitWorldEvent {
             contact_point,
@@ -876,29 +924,47 @@ impl Arena {
         }));
     }
 
-    fn on_car_ball_collision(
-        &mut self,
-        car_idx: usize,
-        manifold_point: &ManifoldPoint,
-        ball_is_body_a: bool,
-    ) {
-        let ball_rb = &mut self.bullet_world.bodies_mut()[self.ball.rigid_body_idx];
-        let ball_accum_vel_before = ball_rb.accum_lin_vel;
+    fn on_car_ball_collision(&mut self, car_idx: usize, contact: &ContactRecord) {
+        if std::env::var("RSIM_CONTACT_DEBUG_STEP")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(self.tick_count)
+        {
+            println!(
+                "rust_car_ball_contact,tick={},car={},a={},b={},swap={},distance={},point_a={:?},point_b={:?},normal={:?},pre_a={:?},pre_b={:?},vel_a={:?},vel_b={:?}",
+                self.tick_count,
+                car_idx,
+                contact.rb_idx_a,
+                contact.rb_idx_b,
+                contact.is_swap,
+                contact.manifold_point.distance_1,
+                contact.manifold_point.pos_world_on_a,
+                contact.manifold_point.pos_world_on_b,
+                contact.manifold_point.normal_world_on_b,
+                contact.pre_pos_a,
+                contact.pre_pos_b,
+                contact.pre_vel_a,
+                contact.pre_vel_b,
+            );
+        }
         self.ball.on_hit(
             &self.cars[car_idx],
+            contact.pre_pos_a,
+            contact.pre_vel_a,
+            contact.pre_pos_b,
+            contact.pre_vel_b,
             self.config.game_mode,
             &self.config.mutators,
             self.tick_count,
-            ball_rb,
         );
 
-        let contact_point = if ball_is_body_a {
-            manifold_point.pos_world_on_a
+        let contact_point = if contact.is_swap {
+            contact.manifold_point.pos_world_on_a
         } else {
-            manifold_point.pos_world_on_b
+            contact.manifold_point.pos_world_on_b
         } * BT_TO_UU;
 
-        let extra_hit_vel = (ball_rb.accum_lin_vel - ball_accum_vel_before) * BT_TO_UU;
+        let extra_hit_vel = self.ball.velocity_impulse_cache * BT_TO_UU;
         self.events.push(ArenaEvent::CarHitBall(CarHitBallEvent {
             car_idx,
             contact_point,
@@ -907,6 +973,21 @@ impl Arena {
     }
 
     fn on_car_world_collision(&mut self, car_idx: usize, manifold_point: &ManifoldPoint) {
+        if std::env::var("RSIM_CONTACT_DEBUG_STEP")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(self.tick_count)
+        {
+            println!(
+                "rust_car_world_contact,tick={},car={},distance={},point_a={:?},point_b={:?},normal={:?}",
+                self.tick_count,
+                car_idx,
+                manifold_point.distance_1,
+                manifold_point.pos_world_on_a,
+                manifold_point.pos_world_on_b,
+                manifold_point.normal_world_on_b,
+            );
+        }
         self.events.push(ArenaEvent::CarHitWorld(CarHitWorldEvent {
             car_idx,
             contact_point: manifold_point.pos_world_on_b * BT_TO_UU,

--- a/rocketsim/src/sim/ball/base.rs
+++ b/rocketsim/src/sim/ball/base.rs
@@ -18,6 +18,7 @@ use crate::{
                 ActivationState, CollisionFlags, Impulse, RigidBody, RigidBodyConstructionInfo,
             },
         },
+        linear_math::bullet_safe_normalize,
     },
     consts::{BT_TO_UU, TICK_TIME, UU_TO_BT, dropshot, heatseeker, snowday},
     get_neighbor_indices_1, get_neighbor_indices_2, get_tile_pos,
@@ -29,9 +30,21 @@ pub(crate) struct Ball {
     pub state: BallState,
     pub rigid_body_idx: usize,
     pub ground_stick_applied: bool,
+    // V2 defers post-solver ball impulses (car-hit extra velocity and
+    // mode-specific wall bounces) until Ball::_FinishPhysicsTick. Keep the
+    // same cache in Rust instead of putting them into the next solver step.
+    pub velocity_impulse_cache: Vec3A,
 }
 
 impl Ball {
+    /// Match RocketSim v2's scalar `Vec::Length()`, whose components are
+    /// already in UU and whose arithmetic is not Bullet's packed reduction.
+    #[inline]
+    fn legacy_length(v: Vec3A) -> f32 {
+        let length_sq = v.x * v.x + v.y * v.y + v.z * v.z;
+        length_sq.sqrt()
+    }
+
     fn make_ball_collision_shape(
         game_mode: GameMode,
         mutator_config: &MutatorConfig,
@@ -108,6 +121,7 @@ impl Ball {
             state: BallState::DEFAULT,
             rigid_body_idx,
             ground_stick_applied: false,
+            velocity_impulse_cache: Vec3A::ZERO,
         }
     }
 
@@ -123,6 +137,10 @@ impl Ball {
         rb.set_lin_vel(state.phys.vel * UU_TO_BT);
         rb.set_ang_vel(state.phys.ang_vel);
         rb.update_inertia_tensor();
+
+        // Match Ball::SetState in V2: a state restore starts with no pending
+        // post-tick velocity impulse.
+        self.velocity_impulse_cache = Vec3A::ZERO;
 
         if state.phys.vel != Vec3A::ZERO || state.phys.ang_vel != Vec3A::ZERO {
             rb.set_activation_state(ActivationState::Active);
@@ -230,7 +248,27 @@ impl Ball {
         }
     }
 
-    pub(crate) fn finish_physics_tick(&mut self, rb: &mut RigidBody) {
+    pub(crate) fn finish_physics_tick(
+        &mut self,
+        rb: &mut RigidBody,
+        mutator_config: &MutatorConfig,
+    ) {
+        // V2 applies its velocity impulse cache after Bullet has finished the
+        // tick and before exposing the recorded state. Applying this here keeps
+        // car-ball and mode-specific wall impulses on the same tick.
+        if self.velocity_impulse_cache != Vec3A::ZERO {
+            rb.lin_vel += self.velocity_impulse_cache;
+            self.velocity_impulse_cache = Vec3A::ZERO;
+        }
+
+        // V2 clamps gameplay velocities after Bullet integration (and after
+        // applying any cached gameplay impulse). Keep the ball's angular
+        // velocity clamp in the same post-tick position; without it a sphere
+        // can expose solver angular velocity above BALL_MAX_ANG_SPEED.
+        rb.limit_vels(
+            mutator_config.ball_max_speed * UU_TO_BT,
+            consts::ball::MAX_ANG_SPEED,
+        );
         self.state.phys.vel = rb.lin_vel * BT_TO_UU;
         self.state.phys.ang_vel = rb.ang_vel;
 
@@ -244,18 +282,38 @@ impl Ball {
     pub(crate) fn on_hit(
         &mut self,
         car: &Car,
+        car_pos_bt: Vec3A,
+        car_vel_bt: Vec3A,
+        ball_pos_bt: Vec3A,
+        ball_vel_bt: Vec3A,
         game_mode: GameMode,
         mutator_config: &MutatorConfig,
         tick_count: u64,
-        rb: &mut RigidBody,
     ) {
         let car_forward = car.state.phys.rot_mat.x_axis;
-        let rel_pos = self.state.phys.pos - car.state.phys.pos;
-        let rel_vel = self.state.phys.vel - car.state.phys.vel;
+        // Arena drains contact records after rigid-body integration, while V2
+        // invokes semantic contact handling before that integration. Use the
+        // snapshots captured at contact generation time.
+        let car_pos = car_pos_bt * BT_TO_UU;
+        let car_vel = car_vel_bt * BT_TO_UU;
+        let ball_pos = ball_pos_bt * BT_TO_UU;
+        let ball_vel = ball_vel_bt * BT_TO_UU;
+        let rel_pos = ball_pos - car_pos;
+        let rel_vel = ball_vel - car_vel;
 
-        let rel_speed = rel_vel
-            .length()
-            .min(consts::ball::car_hit_impulse::MAX_DELTA_VEL_UU);
+        let debug_hit = std::env::var("RSIM_DEBUG_BALL_HIT_STEP")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            == Some(tick_count);
+        if debug_hit {
+            println!(
+                "rust_ball_input,tick={},car_forward={:?},rel_pos={:?},rel_vel={:?}",
+                tick_count, car_forward, rel_pos, rel_vel
+            );
+        }
+
+        let rel_speed =
+            Self::legacy_length(rel_vel).min(consts::ball::car_hit_impulse::MAX_DELTA_VEL_UU);
 
         // Prevent repeated extra impulses
         let can_accel = self
@@ -274,22 +332,30 @@ impl Ball {
                 consts::ball::car_hit_impulse::Z_SCALE_NORMAL
             };
 
-            let mut hit_dir = (rel_pos * Vec3A::new(1.0, 1.0, z_scale)).normalize_or_zero();
+            // V2 converts the component-wise `Vec` product to btVector3 and
+            // calls `safeNormalized()`.  Use Bullet's SSE dot reduction and
+            // scalar-sqrt reciprocal sequence here, not glam normalization.
+            let mut hit_dir = bullet_safe_normalize(rel_pos * Vec3A::new(1.0, 1.0, z_scale));
             let forward_dir_adjustment = car_forward
                 * hit_dir.dot(car_forward)
                 * const { 1.0 - consts::ball::car_hit_impulse::FORWARD_SCALE };
-            hit_dir = (hit_dir - forward_dir_adjustment).normalize_or_zero();
+            hit_dir = bullet_safe_normalize(hit_dir - forward_dir_adjustment);
 
             let added_hit_impulse = hit_dir
                 * rel_speed
                 * consts::curves::BALL_CAR_EXTRA_IMPULSE_FACTOR.get_output(rel_speed)
                 * mutator_config.ball_hit_extra_force_scale;
-            rb.add_impulse(
-                None,
-                Impulse::Linear(added_hit_impulse * UU_TO_BT),
-                false,
-                true,
-            );
+            if debug_hit {
+                println!(
+                    "rust_ball_output,tick={},rel_speed={},hit_dir={:?},added_vel={:?},scale={}",
+                    tick_count,
+                    rel_speed,
+                    hit_dir,
+                    added_hit_impulse,
+                    mutator_config.ball_hit_extra_force_scale
+                );
+            }
+            self.velocity_impulse_cache += added_hit_impulse * UU_TO_BT;
 
             self.state.last_extra_hit_tick = Some(tick_count);
         }
@@ -315,8 +381,8 @@ impl Ball {
                 let accumulated_hit_force = &mut self.state.ds_info.accumulated_hit_force;
                 let charge_level = &mut self.state.ds_info.charge_level;
 
-                let dir_from_car = (self.state.phys.pos - car.state.phys.pos).normalize_or_zero();
-                let rel_vel_from_car = car.state.phys.vel - self.state.phys.vel;
+                let dir_from_car = rel_pos.normalize_or_zero();
+                let rel_vel_from_car = -rel_vel;
                 let vel_info_ball = dir_from_car.dot(rel_vel_from_car);
 
                 if vel_info_ball >= dropshot::MIN_CHARGE_HIT_SPEED {
@@ -338,7 +404,14 @@ impl Ball {
         }
     }
 
-    pub(crate) fn on_world_hit(&mut self, rb: &mut RigidBody, game_mode: GameMode, normal: Vec3A) {
+    pub(crate) fn on_world_hit(
+        &mut self,
+        rb: &mut RigidBody,
+        game_mode: GameMode,
+        normal: Vec3A,
+        pre_pos_bt: Vec3A,
+        pre_vel_bt: Vec3A,
+    ) {
         match game_mode {
             GameMode::Heatseeker => {
                 const ARENA_EXTENT: Vec3A = consts::arena::get_aabb(GameMode::Soccar).max;
@@ -348,7 +421,9 @@ impl Ball {
 
                 let y_target_dir = f32::from(self.state.hs_info.y_target_dir);
                 let rel_normal_y = normal.y * y_target_dir;
-                let rel_y = self.state.phys.pos.y * y_target_dir;
+                let ball_pos = pre_pos_bt * BT_TO_UU;
+                let ball_vel = pre_vel_bt * BT_TO_UU;
+                let rel_y = ball_pos.y * y_target_dir;
                 if rel_normal_y <= -heatseeker::WALL_BOUNCE_CHANGE_Y_NORMAL
                     && rel_y >= ARENA_EXTENT.y - heatseeker::WALL_BOUNCE_CHANGE_Y_THRESH
                 {
@@ -362,23 +437,20 @@ impl Ball {
                     );
 
                     // Add wall bounce impulse
-                    let dir_to_goal = (goal_target_pos - self.state.phys.pos).normalize_or_zero();
+                    let dir_to_goal = (goal_target_pos - ball_pos).normalize_or_zero();
 
                     let bounce_dir = dir_to_goal * (1.0 - heatseeker::WALL_BOUNCE_UP_FRAC)
                         + Vec3A::Z * heatseeker::WALL_BOUNCE_UP_FRAC;
-                    let bounce_impulse = bounce_dir
-                        * self.state.phys.vel.length()
-                        * heatseeker::WALL_BOUNCE_FORCE_SCALE;
-                    rb.add_impulse(
-                        None,
-                        Impulse::Linear(bounce_impulse * UU_TO_BT),
-                        false,
-                        true,
-                    );
+                    let bounce_impulse =
+                        bounce_dir * ball_vel.length() * heatseeker::WALL_BOUNCE_FORCE_SCALE;
+                    self.velocity_impulse_cache += bounce_impulse * UU_TO_BT;
                 }
             }
             GameMode::Snowday if !self.ground_stick_applied => {
                 let force = -normal * snowday::PUCK_GROUND_STICK_FORCE * TICK_TIME;
+                // This is a force in V2 and is intentionally solver-applied;
+                // unlike velocity impulses it is not part of the post-tick
+                // cache.
                 rb.add_impulse(None, Impulse::Linear(force), true, true);
                 self.ground_stick_applied = true;
             }

--- a/rocketsim/src/sim/boost_pad/base.rs
+++ b/rocketsim/src/sim/boost_pad/base.rs
@@ -39,7 +39,11 @@ impl BoostPad {
             mutator_config.boost_pad_amount_small
         };
 
-        let extent = Vec3A::new(box_radius, box_radius, boost_pads::CYL_HEIGHT);
+        // The collision query uses the cylinder-origin radius.  The broadphase
+        // AABB must therefore cover that cylinder, not just the (smaller) box
+        // hitbox used for the locked-car path.  Using `box_radius` here can
+        // cull a valid big-pad pickup before `process_node` checks CYL_RAD_BIG.
+        let extent = Vec3A::new(cyl_radius, cyl_radius, boost_pads::CYL_HEIGHT);
         let aabb = Aabb::new(config.pos - extent, config.pos + extent);
 
         Self {

--- a/rocketsim/src/sim/car/base.rs
+++ b/rocketsim/src/sim/car/base.rs
@@ -1,6 +1,7 @@
 use std::{
     f32::consts::PI,
     ops::{Deref, DerefMut},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use fastrand::Rng;
@@ -32,6 +33,8 @@ use crate::{
     sim::{UserInfoTypes, car::car_info::CarInfo},
 };
 
+static UPDATE_WHEELS_TRACE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
 pub struct Car {
     pub(crate) info: CarInfo,
     pub(crate) bullet_vehicle: VehicleRL,
@@ -54,6 +57,16 @@ impl DerefMut for Car {
 }
 
 impl Car {
+    #[inline]
+    fn apply_torque(rb: &mut RigidBody, torque: Vec3A, scale: f32) {
+        // V2 calls applyTorque(I_world^-1 * torque), then Bullet's solver
+        // multiplies by I_world. Preserve the same matrix sequence.
+        let inv_inertia = rb.inv_inertia_tensor_world;
+        let torque_impulse = inv_inertia.inverse() * torque * scale;
+        let angular_delta = inv_inertia.transpose() * torque_impulse * TICK_TIME;
+        rb.add_impulse(None, Impulse::Angular(angular_delta), false, true);
+    }
+
     pub(crate) fn new(
         idx: usize,
         team: Team,
@@ -216,6 +229,7 @@ impl Car {
         forward_speed_uu: f32,
         mutator_config: &MutatorConfig,
     ) {
+        let trace_call = UPDATE_WHEELS_TRACE_CALLS.fetch_add(1, Ordering::Relaxed);
         let handbrake_delta = if self.state.controls.handbrake {
             drive_consts::POWERSLIDE_RISE_RATE
         } else {
@@ -263,6 +277,43 @@ impl Car {
             * const { drive_consts::THROTTLE_TORQUE_AMOUNT * UU_TO_BT }
             * drive_speed_scale;
         let drive_brake_force = real_brake * const { drive_consts::BRAKE_TORQUE_AMOUNT * UU_TO_BT };
+        if std::env::var("RSIM_UPDATE_WHEELS_TRACE_CALL")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            == Some(trace_call)
+        {
+            let throttle = self.state.controls.throttle;
+            let steer = self.state.controls.steer;
+            let pitch = self.state.controls.pitch;
+            let yaw = self.state.controls.yaw;
+            let roll = self.state.controls.roll;
+            let jump = self.state.controls.jump;
+            let boost = self.state.controls.boost;
+            let handbrake = self.state.controls.handbrake;
+            println!(
+                "rust_update_wheels,call={},body={},controls=({},{},{},{},{},{},{},{}),num_contact={},forward_uu={},abs_forward_uu={},real_throttle={},engine_throttle={},real_brake={},drive_scale={},engine_force={},brake_force={},handbrake={}",
+                trace_call,
+                self.rigid_body_idx,
+                throttle,
+                steer,
+                pitch,
+                yaw,
+                roll,
+                jump as u8,
+                boost as u8,
+                handbrake as u8,
+                num_wheels_in_contact,
+                forward_speed_uu,
+                abs_forward_speed_uu,
+                real_throttle,
+                engine_throttle,
+                real_brake,
+                drive_speed_scale,
+                drive_engine_force,
+                drive_brake_force,
+                self.state.handbrake_val,
+            );
+        }
         for wheel in &mut self.bullet_vehicle.wheels {
             wheel.engine_force = drive_engine_force;
             wheel.brake = drive_brake_force;
@@ -284,8 +335,13 @@ impl Car {
         self.bullet_vehicle.wheels[0].steer_angle = steer_angle;
         self.bullet_vehicle.wheels[1].steer_angle = steer_angle;
 
-        // fresh raycast contact must not produce sticky force within its own tick
-        if self.sticky_gate_prev {
+        let wheels_have_world_contact = self.bullet_vehicle.wheels.iter().any(|wheel| {
+            wheel
+                .raycast_info
+                .as_ref()
+                .is_some_and(|info| info.is_in_contact_with_world)
+        });
+        if wheels_have_world_contact {
             let upwards_dir = self.bullet_vehicle.get_upwards_dir_from_wheel_contacts(rb);
 
             let full_stick = real_throttle != 0.0
@@ -321,6 +377,14 @@ impl Car {
         let dir_yaw = up_dir;
         let dir_roll = -forward_dir;
 
+        // V2 expires the active flip torque window at the start of the air
+        // torque update.  Keep the state transition in the same place so the
+        // following control-gating branch sees the same `isFlipping` value.
+        if self.state.is_flipping {
+            self.state.is_flipping =
+                self.state.has_flipped && self.state.flip_time < car_consts::flip::TORQUE_TIME;
+        }
+
         let mut do_air_control = false;
         if self.state.is_flipping && update_air_control {
             if self.state.flip_rel_torque == Vec3A::ZERO {
@@ -338,40 +402,8 @@ impl Car {
                 }
 
                 rel_dodge_torque.y *= pitch_scale;
-                let dodge_torque = rel_dodge_torque * flip::TORQUE * TICK_TIME;
-
-                rb.add_impulse(
-                    None,
-                    Impulse::Angular(rb.get_world_trans().matrix3 * dodge_torque),
-                    false,
-                    true,
-                );
-
-                let damp_pitch = dir_pitch.dot(rb.ang_vel) * air_control::DAMPING.x;
-                let damp_yaw = dir_yaw.dot(rb.ang_vel) * air_control::DAMPING.y;
-                let damp_roll = dir_roll.dot(rb.ang_vel) * air_control::DAMPING.z;
-                let damping = dir_yaw * damp_yaw + dir_pitch * damp_pitch + dir_roll * damp_roll;
-                rb.add_impulse(
-                    None,
-                    Impulse::Angular(
-                        damping * const { air_control::TORQUE_APPLY_SCALE * TICK_TIME },
-                    ),
-                    false,
-                    true,
-                );
-
-                let proj_x = rb.ang_vel.x + rb.accum_ang_vel.x;
-                if proj_x > flip::SPIN_CAP_X {
-                    rb.accum_ang_vel.x -= proj_x - flip::SPIN_CAP_X;
-                } else if proj_x < -flip::SPIN_CAP_X {
-                    rb.accum_ang_vel.x -= proj_x + flip::SPIN_CAP_X;
-                }
-                let proj_y = rb.ang_vel.y + rb.accum_ang_vel.y;
-                if proj_y > flip::SPIN_CAP_Y {
-                    rb.accum_ang_vel.y -= proj_y - flip::SPIN_CAP_Y;
-                } else if proj_y < -flip::SPIN_CAP_Y {
-                    rb.accum_ang_vel.y -= proj_y + flip::SPIN_CAP_Y;
-                }
+                let dodge_torque = rb.get_world_trans().matrix3 * (rel_dodge_torque * flip::TORQUE);
+                Self::apply_torque(rb, dodge_torque, 1.0);
             }
         } else {
             do_air_control = true;
@@ -410,20 +442,14 @@ impl Car {
 
             let damping = dir_yaw * damp_yaw + dir_pitch * damp_pitch + dir_roll * damp_roll;
 
-            let rb_torque =
-                (torque - damping) * const { air_control::TORQUE_APPLY_SCALE * TICK_TIME };
-
-            rb.add_impulse(None, Impulse::Angular(rb_torque), false, true);
+            Self::apply_torque(rb, torque - damping, air_control::TORQUE_APPLY_SCALE);
         }
 
-        let throttle_scale = if self.state.controls.boost {
-            1.0
-        } else {
-            self.state.controls.throttle
-        };
-        if throttle_scale != 0.0 {
+        // Boost acceleration is applied separately by update_boost.  V2 only
+        // uses the throttle input for this small airborne engine force.
+        if self.state.controls.throttle != 0.0 {
             let throttle_force = forward_dir
-                * throttle_scale
+                * self.state.controls.throttle
                 * const { car_consts::drive::THROTTLE_AIR_ACCEL * UU_TO_BT * TICK_TIME };
             rb.add_impulse(None, Impulse::Linear(throttle_force), false, true);
         }
@@ -439,39 +465,56 @@ impl Car {
 
         let up_dir = self.state.get_up_dir();
 
-        // Check jump activation
-        if !self.state.has_jumped && self.state.is_on_ground && jump_pressed {
+        // Mirror V2's float `jumpTime` state with the integer tick counter.
+        // V2 tests the elapsed time before applying this tick's force, then
+        // increments it afterwards while either jumping or having jumped.
+        if self.state.is_on_ground && !self.state.is_jumping {
+            if self.state.has_jumped
+                && self.state.jump_time() < jump::MIN_TIME + jump::RESET_TIME_PAD
+            {
+                // Keep has_jumped set while the car is still settling on the
+                // ground; V2 deliberately delays the reset by this pad.
+            } else {
+                self.state.has_jumped = false;
+                self.state.jump_ticks = 0;
+            }
+        }
+
+        if self.state.is_jumping {
+            let jump_time = self.state.jump_time();
+            self.state.is_jumping = jump_time < jump::MIN_TIME
+                || (self.state.controls.jump && jump_time < jump::MAX_TIME);
+        } else if self.state.is_on_ground && jump_pressed {
             self.state.is_jumping = true;
-            self.state.has_jumped = true;
             self.state.jump_ticks = 0;
+
+            // First tick of jumping: apply initial impulse.
+            let jump_start_force = up_dir * mutator_config.jump_immediate_force * UU_TO_BT;
+            rb.add_impulse(
+                Some("Jump"),
+                Impulse::Linear(jump_start_force),
+                false,
+                false,
+            );
         }
 
-        self.state.jump_ticks += 1;
-
         if self.state.is_jumping {
-            self.state.is_jumping = self.state.jump_ticks <= jump::MIN_TICKS
-                || (self.state.controls.jump && self.state.jump_ticks <= jump::MAX_TICKS);
-            if !self.state.is_jumping {
-                // Jump ended this tick: counter restarts
-                self.state.jump_ticks = 1;
-            }
-        }
+            self.state.has_jumped = true;
 
-        // Apply forces (only if still jumping)
-        if self.state.is_jumping {
-            if self.state.jump_ticks == 1 {
-                // First tick of jumping: apply initial impulse.
-                let jump_start_force = up_dir * mutator_config.jump_immediate_force * UU_TO_BT;
-                rb.add_impulse(
-                    Some("Jump"),
-                    Impulse::Linear(jump_start_force),
-                    false,
-                    false,
-                );
-            }
-
-            let jump_force = up_dir * mutator_config.jump_accel * const { UU_TO_BT * TICK_TIME };
+            let jump_force_scale = if self.state.jump_time() < jump::MIN_TIME {
+                0.62
+            } else {
+                1.0
+            };
+            let jump_force = up_dir
+                * mutator_config.jump_accel
+                * jump_force_scale
+                * const { UU_TO_BT * TICK_TIME };
             rb.add_impulse(Some("Jump"), Impulse::Linear(jump_force), false, true);
+        }
+
+        if self.state.is_jumping || self.state.has_jumped {
+            self.state.jump_ticks = self.state.jump_ticks.saturating_add(1);
         }
     }
 
@@ -484,7 +527,10 @@ impl Car {
                     world_contact_normal.z > car_consts::autoflip::NORM_Z_THRESH
                 })
         {
-            let (_, _, roll) = self.state.phys.rot_mat.to_euler(EulerRot::ZYX);
+            // Bullet's Angle::FromRotMat negates the roll returned by
+            // getEulerYPR; glam's ZYX decomposition uses the opposite sign.
+            let (_, _, roll_raw) = self.state.phys.rot_mat.to_euler(EulerRot::ZYX);
+            let roll = -roll_raw;
             let abs_roll = roll.abs();
             if abs_roll > car_consts::autoflip::ROLL_THRESH {
                 self.state.auto_flip_timer = car_consts::autoflip::TIME * (abs_roll / PI);
@@ -541,14 +587,20 @@ impl Car {
                 + self.state.controls.roll.abs();
             let is_flip_input = input_magnitude >= self.config.dodge_deadzone;
 
-            let can_use = !self.state.is_auto_flipping
+            let mut can_use = (!self.state.is_auto_flipping
                 && !self.state.has_double_jumped
-                && !self.state.has_flipped
+                && !self.state.has_flipped)
                 || if is_flip_input {
                     mutator_config.unlimited_flips
                 } else {
                     mutator_config.unlimited_double_jumps
                 };
+
+            // V2 applies the auto-flip veto after selecting the relevant
+            // unlimited-flip/double-jump override.
+            if self.state.is_auto_flipping {
+                can_use = false;
+            }
 
             if can_use {
                 if is_flip_input {
@@ -603,11 +655,20 @@ impl Car {
                             initial_dodge_vel.x *= car_consts::flip::BACKWARD_IMPULSE_SCALE_X;
                         }
 
-                        let forward_dir_2d =
-                            self.state.get_forward_dir().with_z(0.0).normalize_or_zero();
-                        let right_dir_2d = Vec3A::new(-forward_dir_2d.y, forward_dir_2d.x, 0.0);
-                        let final_delta_vel = initial_dodge_vel.x * forward_dir_2d
-                            + initial_dodge_vel.y * right_dir_2d;
+                        // Match V2's explicit atan2 basis construction (the
+                        // sign on the second component is intentional).
+                        let forward = self.state.get_forward_dir();
+                        let forward_ang = forward.y.atan2(forward.x);
+                        let x_vel_dir = Vec3A::new(forward_ang.cos(), -forward_ang.sin(), 0.0);
+                        let y_vel_dir = Vec3A::new(forward_ang.sin(), forward_ang.cos(), 0.0);
+                        // V2 stores the two basis dot products directly as the
+                        // world-space X/Y components (rather than rebuilding a
+                        // vector from the basis). Preserve that quirk for parity.
+                        let final_delta_vel = Vec3A::new(
+                            initial_dodge_vel.dot(x_vel_dir),
+                            initial_dodge_vel.dot(y_vel_dir),
+                            0.0,
+                        );
 
                         rb.add_impulse(
                             None,
@@ -631,15 +692,19 @@ impl Car {
         }
 
         if self.state.is_flipping {
+            // V2 increments flip time before evaluating the z-damping window.
+            // This makes the first damping tick the one whose resulting
+            // flip_time reaches Z_DAMP_START (rather than the preceding tick).
             let flip_time_pre = self.state.flip_time;
             self.state.is_flipping =
                 self.state.has_flipped && flip_time_pre < car_consts::flip::TORQUE_TIME;
             self.state.flip_time = flip_time_pre + TICK_TIME;
-            if flip_time_pre <= car_consts::flip::TORQUE_TIME
-                && flip_time_pre >= car_consts::flip::Z_DAMP_START
-                && (rb.lin_vel.z < 0.0 || flip_time_pre < car_consts::flip::Z_DAMP_END)
+            if self.state.flip_time <= car_consts::flip::TORQUE_TIME
+                && self.state.flip_time >= car_consts::flip::Z_DAMP_START
+                && (rb.lin_vel.z < 0.0 || self.state.flip_time < car_consts::flip::Z_DAMP_END)
             {
-                rb.lin_vel.z *= 1.0 - car_consts::flip::Z_DAMP_120;
+                rb.lin_vel.z *=
+                    (1.0 - car_consts::flip::Z_DAMP_120).powf(TICK_TIME / (1.0 / 120.0));
             }
         } else if self.state.has_flipped {
             self.state.flip_time += TICK_TIME;
@@ -679,14 +744,10 @@ impl Car {
             true,
         );
 
-        rb.add_impulse(
-            None,
-            Impulse::Angular(
-                (torque_forward + torque_right)
-                    * const { car_consts::autoroll::TORQUE * TICK_TIME },
-            ),
-            false,
-            true,
+        Self::apply_torque(
+            rb,
+            torque_forward + torque_right,
+            car_consts::autoroll::TORQUE,
         );
     }
 
@@ -760,29 +821,60 @@ impl Car {
             self.state.controls = self.state.controls.clamp();
         }
 
+        // RocketSim v2 updates suspension/raycast contacts before any wheel,
+        // jump, air-control, or boost logic. The previous Rust order used the
+        // prior tick's contact flags, which changes grounded drive and torque
+        // on the first tick after a state restore.
+        self.bullet_vehicle.update_first(collision_world, TICK_TIME);
+
+        let mut num_wheels_in_contact = 0usize;
+        for (wheel, has_contact) in self
+            .bullet_vehicle
+            .wheels
+            .iter()
+            .zip(&mut self.state.wheels_with_contact)
+        {
+            let in_contact = wheel.raycast_info.is_some();
+            *has_contact = in_contact;
+            num_wheels_in_contact += usize::from(in_contact);
+        }
+        self.state.is_on_ground = num_wheels_in_contact >= 3;
+
         let forward_speed_uu =
             collision_world.bodies()[self.rigid_body_idx].get_forward_speed() * BT_TO_UU;
-
         let jump_pressed = self.state.controls.jump && !self.state.prev_controls.jump;
+        {
+            let rb = &mut collision_world.bodies_mut()[self.rigid_body_idx];
+            self.update_wheels(rb, num_wheels_in_contact, forward_speed_uu, mutator_config);
+        }
+
+        let real_throttle = if self.state.controls.boost && self.state.boost > 0.0 {
+            1.0
+        } else {
+            self.state.controls.throttle
+        };
+        self.bullet_vehicle.update_friction_coefficients(
+            collision_world,
+            self.state.handbrake_val,
+            real_throttle,
+            self.info.config.three_wheels,
+        );
 
         let rb = &mut collision_world.bodies_mut()[self.rigid_body_idx];
 
-        // TODO: Refactor and move
-        let num_wheels_in_contact = self.state.num_wheels_in_contact();
-
-        self.update_wheels(rb, num_wheels_in_contact, forward_speed_uu, mutator_config);
-
-        if self.state.is_on_ground {
+        // RocketSim v2 applies air torque immediately after wheel setup, before
+        // jump/flip state updates.  This ordering matters because the flip
+        // state gates pitch control and the accumulated impulses are consumed
+        // by the same rigid-body integration step.
+        if num_wheels_in_contact < 3 {
+            self.update_air_torque(rb, num_wheels_in_contact == 0);
+        } else {
             self.state.is_flipping = false;
         }
 
         self.update_jump(rb, mutator_config, jump_pressed);
         self.update_auto_flip(rb, jump_pressed);
         self.update_double_jump_or_flip(rb, mutator_config, jump_pressed, forward_speed_uu);
-
-        if !self.state.is_on_ground {
-            self.update_air_torque(rb, num_wheels_in_contact == 0);
-        }
 
         if self.state.controls.throttle != 0.0
             && ((0 < num_wheels_in_contact && num_wheels_in_contact < 4)
@@ -792,35 +884,10 @@ impl Car {
         }
 
         self.state.world_contact_normal = None;
-
+        self.bullet_vehicle
+            .update_second(collision_world, TICK_TIME);
+        let rb = &mut collision_world.bodies_mut()[self.rigid_body_idx];
         self.update_boost(rb, mutator_config);
-
-        let real_throttle = if self.state.controls.boost && self.state.boost > 0.0 {
-            1.0
-        } else {
-            self.state.controls.throttle
-        };
-        self.bullet_vehicle.update(
-            collision_world,
-            TICK_TIME,
-            self.state.handbrake_val,
-            real_throttle,
-            self.info.config.three_wheels,
-        );
-
-        let mut num_wheels_in_contact = 0u8;
-        for (wheel, has_contact) in self
-            .bullet_vehicle
-            .wheels
-            .iter()
-            .zip(&mut self.state.wheels_with_contact)
-        {
-            let in_contact = wheel.raycast_info.is_some();
-            *has_contact = in_contact;
-            num_wheels_in_contact += u8::from(in_contact);
-        }
-        self.state.is_on_ground = num_wheels_in_contact >= 3;
-
         self.sticky_gate_prev = self.bullet_vehicle.wheels.iter().any(|wheel| {
             wheel
                 .raycast_info
@@ -894,6 +961,12 @@ impl Car {
             rb.lin_vel += self.vel_impulse_cache;
             self.vel_impulse_cache = Vec3A::ZERO;
         }
+
+        // RocketSim v2 applies its gameplay velocity limits after Bullet has
+        // integrated the tick. The pre-tick limit in Arena::step_tick keeps
+        // the solver stable, but the post-tick clamp is also observable in
+        // recorded car states (notably during flip torque).
+        rb.limit_vels(car_consts::MAX_SPEED * UU_TO_BT, car_consts::MAX_ANG_SPEED);
 
         self.state.phys.pos = rb.get_world_trans().translation * BT_TO_UU;
         self.state.phys.vel = rb.lin_vel * BT_TO_UU;

--- a/rocketsim/src/sim/car/car_body_config.rs
+++ b/rocketsim/src/sim/car/car_body_config.rs
@@ -11,7 +11,7 @@ pub const HITBOX_SIZES: [Vec3A; 7] = [
 ];
 
 pub const HITBOX_OFFSETS: [Vec3A; 7] = [
-    Vec3A::new(13.8757, 0.0, 20.755),
+    Vec3A::new(13.87566, 0.0, 20.755),
     Vec3A::new(9.0, 0.0, 15.75),
     Vec3A::new(9.00857, 0.0, 12.0942),
     Vec3A::new(12.5, 0.0, 11.75),

--- a/rocketsim/src/sim/consts.rs
+++ b/rocketsim/src/sim/consts.rs
@@ -144,6 +144,9 @@ pub mod car {
     pub mod jump {
         pub const ACCEL: f32 = 4375.0 / 3.0;
         pub const IMMEDIATE_FORCE: f32 = 875.0 / 3.0;
+        pub const MIN_TIME: f32 = 0.025;
+        pub const RESET_TIME_PAD: f32 = 1.0 / 40.0;
+        pub const MAX_TIME: f32 = 0.2;
         /// Minimum hold duration: 3 ticks (0.025 s @ 120 Hz)
         pub const MIN_TICKS: u32 = 3;
         /// Maximum hold duration: 24 ticks (0.2 s @ 120 Hz)


### PR DESCRIPTION
# RocketSim V3 Rust parity fixes

## Summary

This pull request brings the Rust V3 implementation closer to RocketSim V2's
Bullet physics behavior. The changes are generalized engine fixes; they do not
special-case a replay or hard-code a recorded result.

## Confirmed bugs fixed

1. Vehicle contacts and friction were built in a different order, changing
   sequential impulses.
2. Car state/control updates ran in a different phase/order.
3. Airborne boost leaked into the throttle-force path.
4. Early-jump acceleration was not scaled like V2.
5. Flip torque remained active after V2 had expired it.
6. Wheel-friction timing and basis arithmetic differed from V2.
7. Small-angle rotation integration used different thresholding and quaternion
   multiplication order.
8. Flip input basis and veto conditions differed from V2.
9. One external-torque path used the wrong world/local matrix convention.
10. Contact callbacks observed the wrong integration phase.
11. V2 contact overrides and boost-pad broadphase filtering were missing.
12. Car-vs-arena narrowphase now uses the per-triangle GJK path.
13. The Octane compound hitbox offset now matches V2.
14. Cached box proxies now preserve Bullet's margin-free support corner and
    directional margin.
15. EPA witness reconstruction/world-space handling and visibility indexing now
    match Bullet.
16. Automatic flip roll torque used the opposite sign.
17. Wheel ray/support arithmetic now follows Bullet's operation order.
18. State timing and matrix-to-quaternion conventions now match Bullet.
19. Arena mesh BVH construction now follows Bullet's variance/mean split order,
    preserving triangle callback order for sequential manifold solving.
20. Post-tick car-hit and Heatseeker wall-bounce impulses are applied at the
    same stage as V2.

## Validation

The benchmark uses the same 120 Hz RLPR state format, a normalized comparison
threshold of 1.0, and 1,000 deterministic random reset starts for the walking
recording.

### Five-minute Daizen-vs-Daizen tape (36,000 ticks)

| Build | Full-frame pass | Reset pass |
| --- | ---: | ---: |
| V2 C++ | 1,758 / 35,999 (4.8835%) | 99.5583% |
| V3 legacy | 0 / 35,999 (0%) | 80.6856% |
| V3 legacy-v2 | 0 / 35,999 (0%) | 80.5411% |
| V3 fixed | 1,758 / 35,999 (4.8835%) | 99.7194% |

### `walking around bro.rlpr` (36,330 ticks, 1,000 random starts)

| Build | Mean random survival | Random 0/1 | Full-frame | Reset |
| --- | ---: | ---: | ---: | ---: |
| V2 C++ | 153.095 ticks | 0.4% | 2.2049% | 99.9367% |
| V3 legacy | 11.118 ticks | 0% | 0.0055% | 73.3409% |
| V3 legacy-v2 | 11.275 ticks | 0% | 0.0055% | 73.6574% |
| V3 fixed | 150.192 ticks | 0.4% | 2.2049% | 99.5678% |

The Daizen tape used here was generated by V3 Rust, while `walking around
bro.rlpr` was generated by V2. The fixed implementation is substantially
closer in both directions, but this benchmark does not claim bit-for-bit
parity yet; the remaining divergence is documented in `documentation.md`.

## Throughput

Single-run release measurements for 1,000,000 ticks, six cars, and one arena:

| Build | TPS |
| --- | ---: |
| V2 C++ | 58,062 |
| V3 legacy | 238,379 |
| V3 legacy-v2 | 221,948 |
| V3 fixed | 224,724 |

## Setup

Collision meshes are intentionally not committed. Users must provide a valid
mesh directory and call `rocketsim::init(<path>, true)`, or place meshes under
`./collision_meshes/<game-mode>/` and call `init_from_default(true)`.

No Daizen policy/model or absolute local recording path is part of this change.
